### PR TITLE
Align surfaces with global theming

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -2,22 +2,30 @@ import logo from '@/assets/logo.png';
 
 const LoadingScreen = () => {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-primary to-primary-variant">
-      <div className="text-center space-y-6">
+    <div className="relative min-h-screen flex flex-col items-center justify-center bg-gradient-primary text-primary-foreground overflow-hidden">
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-background/40 via-primary/30 to-primary/40 opacity-70"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute -top-32 -right-32 h-[28rem] w-[28rem] rounded-full bg-primary/40 blur-3xl opacity-30"
+        aria-hidden="true"
+      />
+      <div className="relative z-10 text-center space-y-6">
         <div className="relative">
-          <img 
-            src={logo} 
-            alt="BS 피드백 로고" 
-            className="w-24 h-24 mx-auto animate-pulse"
+          <img
+            src={logo}
+            alt="BS 피드백 로고"
+            className="w-24 h-24 mx-auto animate-pulse drop-shadow-xl"
           />
-          <div className="absolute inset-0 bg-white/20 rounded-full animate-ping"></div>
+          <div className="absolute inset-0 rounded-full bg-primary-foreground/20 animate-ping" aria-hidden="true"></div>
         </div>
         <div className="space-y-2">
-          <h1 className="text-2xl font-bold text-white">BS 피드백</h1>
-          <p className="text-white/80">교육과정 피드백 시스템</p>
+          <h1 className="text-2xl font-bold">BS 피드백</h1>
+          <p className="text-primary-foreground/80">교육과정 피드백 시스템</p>
         </div>
         <div className="flex justify-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+          <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary-foreground/80"></div>
         </div>
       </div>
     </div>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -96,9 +96,17 @@ const Auth = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-blue-50 to-purple-50">
+    <div className="relative min-h-screen flex flex-col bg-background text-foreground overflow-hidden">
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-primary/10 to-primary/30 opacity-70"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute -top-48 -right-32 h-[32rem] w-[32rem] rounded-full bg-gradient-primary blur-3xl opacity-25"
+        aria-hidden="true"
+      />
       {/* Header with back button */}
-      <header className="border-b bg-white/95 backdrop-blur-sm sticky top-0 z-50 shadow-sm">
+      <header className="relative z-10 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 shadow-sm">
         <div className="w-full max-w-7xl mx-auto px-4 py-3 flex items-center">
           <Button
             onClick={() => navigate('/')}
@@ -118,9 +126,9 @@ const Auth = () => {
       </header>
 
       {/* Main content - 개선된 반응형 중앙 정렬 */}
-      <div className="flex-1 flex items-center justify-center p-4 sm:p-6 lg:p-8">
+      <div className="relative z-10 flex-1 flex items-center justify-center p-4 sm:p-6 lg:p-8">
         <div className="w-full max-w-sm sm:max-w-md lg:max-w-lg xl:max-w-xl mx-auto">
-          <Card className="w-full shadow-xl border-0 bg-white/95 backdrop-blur-sm">
+          <Card className="w-full shadow-xl border border-border/60 bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/80">
             <CardHeader className="text-center pb-6 px-6 sm:px-8 lg:px-10 pt-8">
               <CardTitle className="text-xl sm:text-2xl lg:text-3xl font-bold">
                 {isResetPassword ? '비밀번호 찾기' : '로그인'}
@@ -154,19 +162,19 @@ const Auth = () => {
                     />
                   </div>
                 )}
-                <Button 
-                  type="submit" 
-                  className="w-full h-12 touch-friendly bg-purple-600 hover:bg-purple-700 text-white text-base font-medium" 
+                <Button
+                  type="submit"
+                  className="w-full h-12 touch-friendly text-base font-medium"
                   disabled={loading}
                 >
                   {loading ? '처리중...' : (isResetPassword ? '비밀번호 재설정 이메일 발송' : '로그인')}
                 </Button>
               </form>
-              
+
               <div className="mt-8 text-center">
                 <Button
                   variant="link"
-                  className="touch-friendly text-purple-600 hover:text-purple-800 text-base"
+                  className="touch-friendly text-base"
                   onClick={() => setIsResetPassword(!isResetPassword)}
                 >
                   {isResetPassword ? '로그인으로 돌아가기' : '비밀번호를 잊으셨나요?'}

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -79,9 +79,17 @@ const ChangePassword = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-green-50 to-blue-50">
+    <div className="relative min-h-screen flex flex-col bg-background text-foreground overflow-hidden">
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/15 via-primary/10 to-primary/25 opacity-70"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute -top-56 -left-32 h-[34rem] w-[34rem] rounded-full bg-gradient-primary blur-3xl opacity-25"
+        aria-hidden="true"
+      />
       {/* Header */}
-      <header className="border-b bg-white/95 backdrop-blur-sm sticky top-0 z-50 shadow-sm">
+      <header className="relative z-10 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 shadow-sm">
         <div className="w-full max-w-7xl mx-auto px-4 py-3 flex items-center">
           <Button
             onClick={() => navigate('/auth')}
@@ -101,9 +109,9 @@ const ChangePassword = () => {
       </header>
 
       {/* Main content - 개선된 반응형 중앙 정렬 */}
-      <div className="flex-1 flex items-center justify-center p-4 sm:p-6 lg:p-8">
+      <div className="relative z-10 flex-1 flex items-center justify-center p-4 sm:p-6 lg:p-8">
         <div className="w-full max-w-sm sm:max-w-md lg:max-w-lg xl:max-w-xl mx-auto">
-          <Card className="w-full shadow-xl border-0 bg-white/95 backdrop-blur-sm">
+          <Card className="w-full shadow-xl border border-border/60 bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/80">
             <CardHeader className="text-center pb-6 px-6 sm:px-8 lg:px-10 pt-8">
               <CardTitle className="text-xl sm:text-2xl lg:text-3xl font-bold">비밀번호 변경</CardTitle>
             </CardHeader>
@@ -145,18 +153,18 @@ const ChangePassword = () => {
                     required
                   />
                 </div>
-                <Button 
-                  type="submit" 
-                  className="w-full h-12 touch-friendly bg-green-600 hover:bg-green-700 text-white text-base font-medium" 
+                <Button
+                  type="submit"
+                  className="w-full h-12 touch-friendly text-base font-medium"
                   disabled={loading}
                 >
                   {loading ? '변경 중...' : '비밀번호 변경'}
                 </Button>
               </form>
-              
-              <div className="mt-8 p-4 sm:p-6 bg-blue-50 rounded-lg border border-blue-200">
-                <p className="text-sm sm:text-base text-blue-800">
-                  <strong>알림:</strong> 비밀번호 변경 후 대시보드로 이동됩니다.
+
+              <div className="mt-8 p-4 sm:p-6 rounded-lg border border-primary/30 bg-primary/10">
+                <p className="text-sm sm:text-base text-primary">
+                  <strong className="font-semibold">알림:</strong> 비밀번호 변경 후 대시보드로 이동됩니다.
                 </p>
               </div>
             </CardContent>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -176,8 +176,11 @@ const Dashboard = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-white">
-        <div>로딩중...</div>
+      <div className="min-h-screen flex items-center justify-center bg-background text-foreground">
+        <div className="space-y-3 text-center">
+          <div className="mx-auto h-10 w-10 animate-spin rounded-full border-b-2 border-primary"></div>
+          <p className="text-sm text-muted-foreground">로딩중...</p>
+        </div>
       </div>
     );
   }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -29,12 +29,20 @@ const NotFound = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 px-4">
-      <Card className="w-full max-w-md mx-auto shadow-lg border-0 bg-white/95 backdrop-blur-sm">
+    <div className="relative min-h-screen flex items-center justify-center bg-background px-4 text-foreground overflow-hidden">
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/10 via-primary/5 to-primary/20 opacity-70"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute -bottom-40 -right-32 h-[30rem] w-[30rem] rounded-full bg-gradient-primary blur-3xl opacity-20"
+        aria-hidden="true"
+      />
+      <Card className="relative z-10 w-full max-w-md mx-auto shadow-lg border border-border/60 bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/80">
         <CardContent className="p-8 text-center space-y-6">
           {/* 404 아이콘 */}
-          <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto">
-            <AlertCircle className="w-8 h-8 text-red-600" />
+          <div className="w-16 h-16 bg-destructive/10 rounded-full flex items-center justify-center mx-auto">
+            <AlertCircle className="w-8 h-8 text-destructive" />
           </div>
 
           {/* 404 메시지 */}
@@ -49,8 +57,8 @@ const NotFound = () => {
           </div>
 
           {/* 요청된 경로 표시 */}
-          <div className="bg-gray-100 rounded-lg p-3">
-            <p className="text-xs text-gray-600 font-mono break-all">
+          <div className="bg-muted rounded-lg p-3">
+            <p className="text-xs text-muted-foreground font-mono break-all">
               경로: {location.pathname}
             </p>
           </div>

--- a/src/pages/SurveyResults.tsx
+++ b/src/pages/SurveyResults.tsx
@@ -1096,24 +1096,24 @@ const SurveyResults = () => {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-background text-foreground">
       <div className="max-w-7xl mx-auto px-4 py-6">
         {/* Header */}
-        <div className="bg-white rounded-lg shadow-sm border p-6 mb-6">
+        <div className="bg-card text-card-foreground rounded-lg shadow-sm border border-border/60 p-6 mb-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-                <BarChart3 className="h-6 w-6" />
+              <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+                <BarChart3 className="h-6 w-6 text-primary" />
                 설문 결과 분석
               </h1>
-              <p className="text-gray-600 mt-1">
-                {isInstructor && !canViewAll 
-                  ? "본인 담당 설문의 응답을 분석하고 통계를 확인하세요" 
+              <p className="text-muted-foreground mt-1">
+                {isInstructor && !canViewAll
+                  ? "본인 담당 설문의 응답을 분석하고 통계를 확인하세요"
                   : "설문 응답을 분석하고 통계를 확인하세요"}
               </p>
               {isInstructor && !canViewAll && (
-                <div className="mt-2 p-2 bg-blue-50 border border-blue-200 rounded-md">
-                  <p className="text-sm text-blue-700">
+                <div className="mt-2 p-2 bg-primary/10 border border-primary/30 rounded-md text-primary">
+                  <p className="text-sm">
                     💡 강사 권한으로 본인이 담당한 설문 결과만 조회할 수 있습니다.
                   </p>
                 </div>
@@ -1128,10 +1128,10 @@ const SurveyResults = () => {
         </div>
 
         {/* 필터 섹션 */}
-        <div className="bg-white rounded-lg shadow-sm border p-6 mb-6">
+        <div className="bg-card text-card-foreground rounded-lg shadow-sm border border-border/60 p-6 mb-6">
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">교육 연도</label>
+              <label className="block text-sm font-medium text-muted-foreground mb-2">교육 연도</label>
               <Select value={selectedYear} onValueChange={setSelectedYear}>
                 <SelectTrigger>
                   <SelectValue placeholder="전체" />
@@ -1148,7 +1148,7 @@ const SurveyResults = () => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">과정</label>
+              <label className="block text-sm font-medium text-muted-foreground mb-2">과정</label>
               <Select value={selectedCourse} onValueChange={setSelectedCourse}>
                 <SelectTrigger>
                   <SelectValue placeholder="전체" />
@@ -1166,7 +1166,7 @@ const SurveyResults = () => {
 
             {canViewAll && (
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">강사</label>
+                <label className="block text-sm font-medium text-muted-foreground mb-2">강사</label>
                 <Select value={selectedInstructor} onValueChange={setSelectedInstructor}>
                   <SelectTrigger>
                     <SelectValue placeholder="전체" />
@@ -1187,7 +1187,7 @@ const SurveyResults = () => {
         {/* 설문 선택 */}
         <div className="flex flex-col sm:flex-row gap-4">
           <div className="flex-1">
-            <label className="block text-sm font-medium text-gray-700 mb-2">설문 선택</label>
+            <label className="block text-sm font-medium text-muted-foreground mb-2">설문 선택</label>
             <Select value={selectedSurvey} onValueChange={setSelectedSurvey}>
               <SelectTrigger>
                 <SelectValue placeholder="전체 설문" />
@@ -1482,7 +1482,7 @@ const SurveyResults = () => {
         {/* 만족도 트렌드 그래프 */}
         {selectedSurvey && selectedSurvey !== 'all' && courseStats.length > 0 && (
           <div className="mb-6">
-            <h2 className="text-xl font-bold mb-4 text-gray-900">만족도 트렌드 분석</h2>
+            <h2 className="text-xl font-bold mb-4 text-foreground">만족도 트렌드 분석</h2>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
               {/* 과정별 만족도 트렌드 */}
               <Card className="shadow-sm border border-border">


### PR DESCRIPTION
## Summary
- refresh the loading screen and public auth flows with the new gradient-based global styling and primary button palette
- restyle the 404 page and dashboard loading state so their backgrounds, typography, and messaging respect the shared design tokens
- update survey results filters to use theme colors and card surfaces for consistent theming

## Testing
- npm run lint *(fails: missing optional dev dependency `@eslint/js` in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cbea0d3a8883249e83b6fc32c7758b