### PR TITLE
Fix survey status badge for completed surveys

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -154,12 +154,41 @@ const Index = () => {
     setSurveys(filtered);
   };
 
-  const getStatusBadge = (status: string) => {
-    switch (status) {
+  const getSurveyDisplayStatus = (survey: Survey) => {
+    const now = new Date();
+
+    const parseDate = (value?: string) => {
+      if (!value) return null;
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
+    };
+
+    const startDate = parseDate(survey.start_date);
+    const endDate = parseDate(survey.end_date);
+
+    if (endDate && endDate < now) {
+      return 'completed';
+    }
+
+    if (startDate && startDate > now) {
+      return 'upcoming';
+    }
+
+    if (survey.status === 'public') {
+      return 'active';
+    }
+
+    return survey.status;
+  };
+
+  const getStatusBadge = (survey: Survey) => {
+    switch (getSurveyDisplayStatus(survey)) {
       case 'active':
         return <Badge variant="default" className="font-sans">진행중</Badge>;
       case 'completed':
         return <Badge variant="secondary" className="font-sans">완료</Badge>;
+      case 'upcoming':
+        return <Badge variant="outline" className="font-sans">진행예정</Badge>;
       default:
         return <Badge variant="outline" className="font-sans">준비중</Badge>;
     }
@@ -403,7 +432,7 @@ const Index = () => {
                           <CardHeader>
                             <div className="flex items-start justify-between">
                               <CardTitle className="text-lg font-display">{survey.title}</CardTitle>
-                              {getStatusBadge(survey.status)}
+                              {getStatusBadge(survey)}
                             </div>
                             {survey.description && (
                               <CardDescription className="font-sans">{survey.description}</CardDescription>


### PR DESCRIPTION
## Summary
- derive the survey status from start/end dates so completed or upcoming surveys show accurate tags
- update the badge rendering to use the derived status instead of the raw value from Supabase

## Testing
- `npm run build` *(fails: vite not found because dependencies are not installed in the environment)*
- `npm install` *(fails: npm registry responded with 403 when fetching tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_68cbeb7ae3808324b065de036e5cb4a0