### PR TITLE
Restrict course round filter to selected course

### DIFF
--- a/src/components/course-reports/CourseSelector.tsx
+++ b/src/components/course-reports/CourseSelector.tsx
@@ -8,7 +8,7 @@ interface CourseSelectorProps {
   selectedCourse: string;
   selectedRound: number | null;                 // null = 전체
   selectedInstructor: string;                   // ''   = 전체
-  availableCourses: {year: number, round: number, course_name: string, key: string}[];
+  availableCourses: {year: number, round: number, course_name: string, key: string, rounds?: number[]}[];
   availableRounds: number[];
   availableInstructors: {id: string, name: string}[];
   years: number[];


### PR DESCRIPTION
## Summary
- store round lists alongside each course when loading available courses
- update the course selector typing to accept the optional round metadata
- automatically recalculate the available round options whenever the selected course changes so only actual rounds are shown

## Testing
- `npm run lint` *(fails: missing `@eslint/js` because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cbfe067c08832487a4f842e7a8a8dd