### PR TITLE
Fix tooltip percentages for survey charts

### DIFF
--- a/src/pages/PersonalDashboard.tsx
+++ b/src/pages/PersonalDashboard.tsx
@@ -739,7 +739,12 @@ const PersonalDashboard: FC = () => {
                       <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
                     ))}
                   </Pie>
-                  <Tooltip formatter={(value, name) => [`${value}개 (${analysis.chartData.find((d: any) => d.name === name)?.percentage}%)`, name]} />
+                  <Tooltip
+                    formatter={(value: number | string, _name: string, props: any) => {
+                      const percentage = props?.payload?.percentage ?? 0;
+                      return [`${value}개 (${percentage}%)`, props?.payload?.name ?? props?.name ?? ''];
+                    }}
+                  />
                 </PieChart>
               </ResponsiveContainer>
             </div>

--- a/src/pages/SurveyDetailedAnalysis.tsx
+++ b/src/pages/SurveyDetailedAnalysis.tsx
@@ -892,7 +892,12 @@ const SurveyDetailedAnalysis = () => {
                                 <CartesianGrid strokeDasharray="3 3" />
                                 <XAxis dataKey="name" />
                                 <YAxis />
-                                <Tooltip formatter={(value, name) => [`${value}개 (${analysis.chartData.find(d => d.name === name)?.percentage}%)`, '응답 수']} />
+                                <Tooltip
+                                  formatter={(value: number | string, _name: string, props: any) => {
+                                    const percentage = props?.payload?.percentage ?? 0;
+                                    return [`${value}개 (${percentage}%)`, '응답 수'];
+                                  }}
+                                />
                                 <Bar dataKey="value" fill="hsl(var(--chart-1))" />
                               </RechartsBarChart>
                             </ResponsiveContainer>
@@ -1038,7 +1043,12 @@ const SurveyDetailedAnalysis = () => {
                                     <CartesianGrid strokeDasharray="3 3" />
                                     <XAxis dataKey="name" />
                                     <YAxis />
-                                    <Tooltip formatter={(value, name) => [`${value}개 (${analysis.chartData.find(d => d.name === name)?.percentage}%)`, '응답 수']} />
+                                    <Tooltip
+                                      formatter={(value: number | string, _name: string, props: any) => {
+                                        const percentage = props?.payload?.percentage ?? 0;
+                                        return [`${value}개 (${percentage}%)`, '응답 수'];
+                                      }}
+                                    />
                                     <Bar dataKey="value" fill="hsl(var(--chart-1))" />
                                   </RechartsBarChart>
                                 </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- ensure Recharts tooltips in survey detailed analysis use the hovered bar's payload to display the correct percentage
- update personal dashboard pie chart tooltip to rely on payload data so the response percentage is shown instead of `undefined`

## Testing
- `npm run lint` *(fails: missing dependencies because registry access to tailwindcss is forbidden in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc08fd826c83248edc87f5697db53a