### PR TITLE
Fix monthly summary satisfaction scale

### DIFF
--- a/src/pages/DashboardOverview.tsx
+++ b/src/pages/DashboardOverview.tsx
@@ -470,7 +470,7 @@ const DashboardOverview: React.FC = () => {
                   </div>
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-muted-foreground">만족도 평균</span>
-                    <span className="font-semibold text-foreground">4.2/5.0</span>
+                    <span className="font-semibold text-foreground">4.2/10.0</span>
                   </div>
                 </div>
               </CardContent>


### PR DESCRIPTION
## Summary
- update the monthly summary card to display the satisfaction average on a 10-point scale

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68cca5ec0e108324b1656144363cd517