### PR TITLE
Fix test data toggle filtering behavior

### DIFF
--- a/src/hooks/useSurveyResultsData.tsx
+++ b/src/hooks/useSurveyResultsData.tsx
@@ -149,7 +149,11 @@ export const useSurveyResultsData = (profile: any, canViewAll: boolean, isInstru
   const fetchAllResponses = async () => {
     try {
       let query = supabase.from('survey_responses').select('*');
-      
+
+      if (!testDataOptions?.includeTestData) {
+        query = query.or('is_test.is.null,is_test.eq.false');
+      }
+
       // 강사인 경우 자신의 강의 설문에 대한 응답만 조회
       if (isInstructor && profile?.instructor_id && !canViewAll) {
         let surveyQuery = supabase

--- a/src/pages/SurveyResults.tsx
+++ b/src/pages/SurveyResults.tsx
@@ -180,12 +180,15 @@ const SurveyResults = () => {
 
       // 테스트 데이터 필터링
       if (!testDataOptions.includeTestData) {
+        // 테스트 응답 자체 제외
+        query = query.or('is_test.is.null,is_test.eq.false');
+
         // 테스트 설문의 응답 제외
         const { data: nonTestSurveys } = await supabase
           .from('surveys')
           .select('id')
           .or('is_test.is.null,is_test.eq.false');
-        
+
         if (nonTestSurveys && nonTestSurveys.length > 0) {
           const surveyIds = nonTestSurveys.map(s => s.id);
           query = query.in('survey_id', surveyIds);
@@ -297,10 +300,16 @@ const SurveyResults = () => {
       if (qErr) throw qErr;
       setAllQuestions((qData ?? []) as SurveyQuestion[]);
 
-      const { data: respIds, error: rErr } = await supabase
+      let responseQuery = supabase
         .from('survey_responses')
         .select('id')
         .in('survey_id', surveyIds);
+
+      if (!testDataOptions.includeTestData) {
+        responseQuery = responseQuery.or('is_test.is.null,is_test.eq.false');
+      }
+
+      const { data: respIds, error: rErr } = await responseQuery;
       if (rErr) throw rErr;
 
       if (respIds && respIds.length) {
@@ -330,10 +339,16 @@ const SurveyResults = () => {
         .order('order_index');
       if (qErr) throw qErr;
 
-      const { data: rIds, error: rErr } = await supabase
+      let responseQuery = supabase
         .from('survey_responses')
         .select('id')
         .eq('survey_id', selectedSurvey);
+
+      if (!testDataOptions.includeTestData) {
+        responseQuery = responseQuery.or('is_test.is.null,is_test.eq.false');
+      }
+
+      const { data: rIds, error: rErr } = await responseQuery;
       if (rErr) throw rErr;
 
       if (rIds && rIds.length) {


### PR DESCRIPTION
## Summary
- ensure survey result queries exclude test survey responses when the toggle is off
- update cumulative data calculations to ignore test responses and compute satisfaction with the filtered ids
- align shared survey results hook with the new response level filtering

## Testing
- `npm run build` *(fails: vite missing before dependencies were installed)*
- `npm install` *(fails: npm registry returned 403 for tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_68cca61a788883248bc634a65b8c4660