### PR TITLE
Improve empty state with illustration and CTA links

### DIFF
--- a/src/assets/empty-state-illustration.svg
+++ b/src/assets/empty-state-illustration.svg
@@ -1,0 +1,14 @@
+<svg width="320" height="240" viewBox="0 0 320 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="32" y="32" width="256" height="176" rx="24" fill="#F1F5F9" />
+  <rect x="56" y="80" width="160" height="12" rx="6" fill="#CBD5F5" />
+  <rect x="56" y="110" width="208" height="12" rx="6" fill="#DBEAFE" />
+  <rect x="56" y="140" width="180" height="12" rx="6" fill="#E2E8F0" />
+  <circle cx="224" cy="100" r="32" fill="#C4B5FD" opacity="0.5" />
+  <path d="M224 84L232 100H216L224 116" stroke="#7C3AED" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M120 48C120 43.5817 123.582 40 128 40H192C196.418 40 200 43.5817 200 48V56H120V48Z" fill="#1D4ED8" opacity="0.15" />
+  <rect x="120" y="56" width="80" height="8" rx="4" fill="#BFDBFE" />
+  <circle cx="160" cy="188" r="16" fill="#1D4ED8" opacity="0.2" />
+  <path d="M152 188L158 194L168 182" stroke="#1D4ED8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M64 188C64 179.163 71.1634 172 80 172H136" stroke="#E2E8F0" stroke-width="8" stroke-linecap="round" />
+  <path d="M184 172H240C248.837 172 256 179.163 256 188" stroke="#E2E8F0" stroke-width="8" stroke-linecap="round" />
+</svg>


### PR DESCRIPTION
## Summary
- enhance the survey list empty state with a centered layout, illustration, guidance copy, and CTA buttons that open environment-driven links
- read CTA targets from Vite environment variables and surface a toast when URLs are not configured
- add a reusable empty state illustration asset

## Testing
- `npm run lint` *(fails: missing local dev dependencies because installing tailwindcss from the npm registry returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb2d5bbb88324a2c10f53615a0216