### PR TITLE
Add password visibility toggles and caps lock hints

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -3,12 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Eye, EyeOff } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { translateAuthError } from '@/utils/authErrorTranslator';
 import { getBaseUrl } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 const Auth = () => {
   const navigate = useNavigate();
@@ -16,6 +17,8 @@ const Auth = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [isCapsLockOn, setIsCapsLockOn] = useState(false);
   const { toast } = useToast();
 
   const handleLogin = async (e: React.FormEvent) => {
@@ -95,6 +98,14 @@ const Auth = () => {
     }
   };
 
+  const handlePasswordKeyEvent = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (typeof event.getModifierState === 'function') {
+      setIsCapsLockOn(event.getModifierState('CapsLock'));
+    }
+  };
+
+  const handlePasswordBlur = () => setIsCapsLockOn(false);
+
   return (
     <div className="relative min-h-screen flex flex-col bg-background text-foreground overflow-hidden">
       <div
@@ -149,17 +160,50 @@ const Auth = () => {
                   />
                 </div>
                 {!isResetPassword && (
-                  <div className="space-y-3">
-                    <Label htmlFor="password" className="text-sm font-medium">비밀번호</Label>
-                    <Input
-                      id="password"
-                      type="password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      placeholder="비밀번호를 입력하세요"
-                      className="w-full h-12 text-base"
-                      required
-                    />
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <Label htmlFor="password" className="text-sm font-medium">비밀번호</Label>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                            aria-label="비밀번호 정책 안내 보기"
+                          >
+                            비밀번호 정책
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent align="end" className="max-w-xs text-xs leading-relaxed">
+                          최소 6자 이상이며 영문 대·소문자, 숫자, 특수문자를 조합하면 안전합니다.
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                    <div className="relative">
+                      <Input
+                        id="password"
+                        type={showPassword ? 'text' : 'password'}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        onKeyDown={handlePasswordKeyEvent}
+                        onKeyUp={handlePasswordKeyEvent}
+                        onBlur={handlePasswordBlur}
+                        autoComplete="current-password"
+                        placeholder="비밀번호를 입력하세요"
+                        className="w-full h-12 text-base pr-12"
+                        required
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((prev) => !prev)}
+                        className="absolute inset-y-0 right-3 flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                        aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                      >
+                        {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                    {isCapsLockOn && (
+                      <p className="text-xs text-destructive">Caps Lock이 켜져 있습니다.</p>
+                    )}
                   </div>
                 )}
                 <Button

--- a/src/pages/ChangePassword.tsx
+++ b/src/pages/ChangePassword.tsx
@@ -7,7 +7,8 @@ import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/useAuth';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Eye, EyeOff } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 const ChangePassword = () => {
   const navigate = useNavigate();
@@ -17,6 +18,12 @@ const ChangePassword = () => {
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isCurrentCapsLockOn, setIsCurrentCapsLockOn] = useState(false);
+  const [isNewCapsLockOn, setIsNewCapsLockOn] = useState(false);
+  const [isConfirmCapsLockOn, setIsConfirmCapsLockOn] = useState(false);
 
   const handleChangePassword = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -78,6 +85,17 @@ const ChangePassword = () => {
     }
   };
 
+  const handleCapsLockEvent = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    setState: React.Dispatch<React.SetStateAction<boolean>>
+  ) => {
+    if (typeof event.getModifierState === 'function') {
+      setState(event.getModifierState('CapsLock'));
+    }
+  };
+
+  const resetCapsLockState = (setState: React.Dispatch<React.SetStateAction<boolean>>) => () => setState(false);
+
   return (
     <div className="relative min-h-screen flex flex-col bg-background text-foreground overflow-hidden">
       <div
@@ -117,41 +135,141 @@ const ChangePassword = () => {
             </CardHeader>
             <CardContent className="px-6 sm:px-8 lg:px-10 pb-8">
               <form onSubmit={handleChangePassword} className="space-y-6">
-                <div className="space-y-3">
-                  <Label htmlFor="currentPassword" className="text-sm font-medium">현재 비밀번호</Label>
-                  <Input
-                    id="currentPassword"
-                    type="password"
-                    value={currentPassword}
-                    onChange={(e) => setCurrentPassword(e.target.value)}
-                    placeholder="bsedu123"
-                    className="w-full h-12 text-base"
-                    required
-                  />
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <Label htmlFor="currentPassword" className="text-sm font-medium">현재 비밀번호</Label>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                          aria-label="현재 비밀번호 정책 안내"
+                        >
+                          입력 안내
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent align="end" className="max-w-xs text-xs leading-relaxed">
+                        공용 초기 비밀번호를 사용하는 경우 보안을 위해 즉시 변경해주세요.
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className="relative">
+                    <Input
+                      id="currentPassword"
+                      type={showCurrentPassword ? 'text' : 'password'}
+                      value={currentPassword}
+                      onChange={(e) => setCurrentPassword(e.target.value)}
+                      onKeyDown={(event) => handleCapsLockEvent(event, setIsCurrentCapsLockOn)}
+                      onKeyUp={(event) => handleCapsLockEvent(event, setIsCurrentCapsLockOn)}
+                      onBlur={resetCapsLockState(setIsCurrentCapsLockOn)}
+                      autoComplete="current-password"
+                      placeholder="bsedu123"
+                      className="w-full h-12 text-base pr-12"
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowCurrentPassword((prev) => !prev)}
+                      className="absolute inset-y-0 right-3 flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      aria-label={showCurrentPassword ? '현재 비밀번호 숨기기' : '현재 비밀번호 보기'}
+                    >
+                      {showCurrentPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                  {isCurrentCapsLockOn && (
+                    <p className="text-xs text-destructive">Caps Lock이 켜져 있습니다.</p>
+                  )}
                 </div>
-                <div className="space-y-3">
-                  <Label htmlFor="newPassword" className="text-sm font-medium">새 비밀번호</Label>
-                  <Input
-                    id="newPassword"
-                    type="password"
-                    value={newPassword}
-                    onChange={(e) => setNewPassword(e.target.value)}
-                    placeholder="최소 6자 이상"
-                    className="w-full h-12 text-base"
-                    required
-                  />
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <Label htmlFor="newPassword" className="text-sm font-medium">새 비밀번호</Label>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                          aria-label="비밀번호 정책 안내"
+                        >
+                          비밀번호 정책
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent align="end" className="max-w-xs text-xs leading-relaxed">
+                        최소 6자 이상이며 영문 대·소문자, 숫자, 특수문자 중 2가지 이상을 조합하면 안전합니다.
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className="relative">
+                    <Input
+                      id="newPassword"
+                      type={showNewPassword ? 'text' : 'password'}
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      onKeyDown={(event) => handleCapsLockEvent(event, setIsNewCapsLockOn)}
+                      onKeyUp={(event) => handleCapsLockEvent(event, setIsNewCapsLockOn)}
+                      onBlur={resetCapsLockState(setIsNewCapsLockOn)}
+                      autoComplete="new-password"
+                      placeholder="최소 6자 이상"
+                      className="w-full h-12 text-base pr-12"
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowNewPassword((prev) => !prev)}
+                      className="absolute inset-y-0 right-3 flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      aria-label={showNewPassword ? '새 비밀번호 숨기기' : '새 비밀번호 보기'}
+                    >
+                      {showNewPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">안전한 계정을 위해 다른 서비스와 다른 비밀번호를 사용해주세요.</p>
+                  {isNewCapsLockOn && (
+                    <p className="text-xs text-destructive">Caps Lock이 켜져 있습니다.</p>
+                  )}
                 </div>
-                <div className="space-y-3">
-                  <Label htmlFor="confirmPassword" className="text-sm font-medium">새 비밀번호 확인</Label>
-                  <Input
-                    id="confirmPassword"
-                    type="password"
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    placeholder="새 비밀번호를 다시 입력"
-                    className="w-full h-12 text-base"
-                    required
-                  />
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <Label htmlFor="confirmPassword" className="text-sm font-medium">새 비밀번호 확인</Label>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-xs text-muted-foreground underline decoration-dotted underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                          aria-label="비밀번호 확인 안내"
+                        >
+                          확인 안내
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent align="end" className="max-w-xs text-xs leading-relaxed">
+                        새 비밀번호와 동일하게 입력해야 비밀번호가 변경됩니다.
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <div className="relative">
+                    <Input
+                      id="confirmPassword"
+                      type={showConfirmPassword ? 'text' : 'password'}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      onKeyDown={(event) => handleCapsLockEvent(event, setIsConfirmCapsLockOn)}
+                      onKeyUp={(event) => handleCapsLockEvent(event, setIsConfirmCapsLockOn)}
+                      onBlur={resetCapsLockState(setIsConfirmCapsLockOn)}
+                      autoComplete="new-password"
+                      placeholder="새 비밀번호를 다시 입력"
+                      className="w-full h-12 text-base pr-12"
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowConfirmPassword((prev) => !prev)}
+                      className="absolute inset-y-0 right-3 flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      aria-label={showConfirmPassword ? '비밀번호 확인 숨기기' : '비밀번호 확인 보기'}
+                    >
+                      {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                  {isConfirmCapsLockOn && (
+                    <p className="text-xs text-destructive">Caps Lock이 켜져 있습니다.</p>
+                  )}
                 </div>
                 <Button
                   type="submit"


### PR DESCRIPTION
## Summary
- add password visibility toggles to authentication and password change forms
- surface caps lock detection, autocomplete hints, and password policy tooltips for all password inputs

## Testing
- npm run lint *(fails: missing @eslint/js because npm install cannot fetch tailwindcss due to 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb2f3c37483248e57d4a0e3b8d73c