### PR TITLE
Add shared support contact info and enhance error recovery UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -43,6 +44,25 @@ const queryClient = new QueryClient();
 
 function AppContent() {
   const location = useLocation();
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const fullPath = `${location.pathname}${location.search}${location.hash}`;
+
+    try {
+      const stored = window.sessionStorage.getItem("recentPaths");
+      const parsed = stored ? (JSON.parse(stored) as string[]) : [];
+      const filtered = parsed.filter((path) => path && path !== fullPath);
+      const updated = [fullPath, ...filtered].slice(0, 10);
+
+      window.sessionStorage.setItem("recentPaths", JSON.stringify(updated));
+    } catch (storageError) {
+      console.error("최근 방문 경로를 저장하지 못했습니다", storageError);
+    }
+  }, [location.pathname, location.search, location.hash]);
 
   const routes = (
     <Routes>

--- a/src/components/SupportContactInfo.tsx
+++ b/src/components/SupportContactInfo.tsx
@@ -1,0 +1,79 @@
+import { Mail, Phone } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export const DEFAULT_ADMIN_EMAIL = "admin@example.com";
+export const DEFAULT_SURVEY_CONTACT = "support@example.com";
+
+interface SupportContactInfoProps {
+  adminEmail?: string;
+  adminLabel?: string;
+  surveyContact?: string;
+  surveyLabel?: string;
+  description?: string;
+  className?: string;
+}
+
+const sanitizePhone = (value: string) => value.replace(/[^0-9+]/g, "");
+
+const SupportContactInfo = ({
+  adminEmail = DEFAULT_ADMIN_EMAIL,
+  adminLabel = "시스템 관리자",
+  surveyContact = DEFAULT_SURVEY_CONTACT,
+  surveyLabel = "설문 담당자",
+  description = "문제가 계속될 경우 아래 연락처로 문의해 주세요.",
+  className,
+}: SupportContactInfoProps) => {
+  const surveyIsEmail = surveyContact.includes("@");
+  const SurveyIcon = surveyIsEmail ? Mail : Phone;
+  const surveyHref = surveyIsEmail
+    ? `mailto:${surveyContact}`
+    : `tel:${sanitizePhone(surveyContact)}`;
+
+  return (
+    <div
+      className={cn(
+        "space-y-4 rounded-lg border border-border/60 bg-muted/30 p-4",
+        className
+      )}
+    >
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">문의 안내</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <div className="grid gap-3">
+        <div className="flex items-start gap-3 rounded-md border border-border/60 bg-background p-3">
+          <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+            <Mail className="h-4 w-4 text-primary" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">{adminLabel}</p>
+            <a
+              href={`mailto:${adminEmail}`}
+              className="text-sm font-medium text-primary hover:underline break-all"
+            >
+              {adminEmail}
+            </a>
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3 rounded-md border border-border/60 bg-background p-3">
+          <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+            <SurveyIcon className="h-4 w-4 text-primary" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">{surveyLabel}</p>
+            <a
+              href={surveyHref}
+              className="text-sm font-medium text-primary hover:underline break-all"
+            >
+              {surveyContact}
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SupportContactInfo;

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,12 +1,63 @@
 import { useLocation, useNavigate } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Home, ArrowLeft, AlertCircle } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import SupportContactInfo, {
+  DEFAULT_ADMIN_EMAIL,
+  DEFAULT_SURVEY_CONTACT,
+} from "@/components/SupportContactInfo";
+import {
+  Home,
+  ArrowLeft,
+  AlertCircle,
+  Search,
+  LayoutDashboard,
+  ClipboardList,
+  Users,
+  BarChart3,
+  FileText,
+} from "lucide-react";
+
+const quickLinks = [
+  {
+    title: "대시보드",
+    description: "전체 운영 현황과 주요 지표를 확인합니다.",
+    path: "/dashboard",
+    icon: LayoutDashboard,
+  },
+  {
+    title: "설문 관리",
+    description: "설문을 생성하고 배포 상태를 관리합니다.",
+    path: "/dashboard/surveys",
+    icon: ClipboardList,
+  },
+  {
+    title: "강사 관리",
+    description: "강사 정보를 확인하고 권한을 조정합니다.",
+    path: "/dashboard/instructors",
+    icon: Users,
+  },
+  {
+    title: "강의 리포트",
+    description: "강의별 설문 리포트를 빠르게 확인합니다.",
+    path: "/dashboard/course-reports",
+    icon: BarChart3,
+  },
+  {
+    title: "템플릿 관리",
+    description: "설문 템플릿을 생성하고 편집합니다.",
+    path: "/dashboard/templates",
+    icon: FileText,
+  },
+];
 
 const NotFound = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const [recentPages, setRecentPages] = useState<string[]>([]);
+  const [searchTerm, setSearchTerm] = useState("");
+  const currentPath = `${location.pathname}${location.search}${location.hash}`;
 
   useEffect(() => {
     console.error(
@@ -14,6 +65,24 @@ const NotFound = () => {
       location.pathname
     );
   }, [location.pathname]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const stored = window.sessionStorage.getItem("recentPaths");
+      const parsed = stored ? (JSON.parse(stored) as string[]) : [];
+      const filtered = parsed
+        .filter((path) => path && path !== currentPath)
+        .slice(0, 5);
+      setRecentPages(filtered);
+    } catch (storageError) {
+      console.error("최근 방문 페이지를 불러오지 못했습니다", storageError);
+      setRecentPages([]);
+    }
+  }, [currentPath]);
 
   const handleGoHome = () => {
     // 관리자 대시보드에서 온 경우 대시보드로, 그 외에는 메인으로
@@ -28,6 +97,58 @@ const NotFound = () => {
     navigate(-1);
   };
 
+  const filteredQuickLinks = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+
+    if (!term) {
+      return quickLinks;
+    }
+
+    return quickLinks.filter((link) =>
+      [link.title, link.description]
+        .join(" ")
+        .toLowerCase()
+        .includes(term)
+    );
+  }, [searchTerm]);
+
+  const handleSearchSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (filteredQuickLinks.length > 0) {
+      navigate(filteredQuickLinks[0].path);
+    }
+  };
+
+  const getRecentPageLabel = (path: string) => {
+    const quickLinkMatch = quickLinks.find((link) => path.startsWith(link.path));
+    if (quickLinkMatch) {
+      return quickLinkMatch.title;
+    }
+
+    if (path === "/") {
+      return "메인 페이지";
+    }
+
+    if (path.startsWith("/survey-session")) {
+      return "설문 참여 세션";
+    }
+
+    if (path.startsWith("/survey/")) {
+      return "설문 참여";
+    }
+
+    if (path.startsWith("/results")) {
+      return "설문 결과";
+    }
+
+    if (path.startsWith("/auth")) {
+      return "로그인";
+    }
+
+    return path;
+  };
+
   return (
     <div className="relative min-h-screen flex items-center justify-center bg-background px-4 text-foreground overflow-hidden">
       <div
@@ -38,59 +159,132 @@ const NotFound = () => {
         className="pointer-events-none absolute -bottom-40 -right-32 h-[30rem] w-[30rem] rounded-full bg-gradient-primary blur-3xl opacity-20"
         aria-hidden="true"
       />
-      <Card className="relative z-10 w-full max-w-md mx-auto shadow-lg border border-border/60 bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-        <CardContent className="p-8 text-center space-y-6">
+      <Card className="relative z-10 w-full max-w-2xl mx-auto shadow-lg border border-border/60 bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <CardContent className="p-8 space-y-8">
           {/* 404 아이콘 */}
-          <div className="w-16 h-16 bg-destructive/10 rounded-full flex items-center justify-center mx-auto">
-            <AlertCircle className="w-8 h-8 text-destructive" />
+          <div className="text-center space-y-4">
+            <div className="w-16 h-16 bg-destructive/10 rounded-full flex items-center justify-center mx-auto">
+              <AlertCircle className="w-8 h-8 text-destructive" />
+            </div>
+
+            <div className="space-y-3">
+              <h1 className="text-4xl md:text-5xl font-bold text-foreground font-display">404</h1>
+              <h2 className="text-lg md:text-xl font-semibold text-foreground font-display">
+                페이지를 찾을 수 없습니다
+              </h2>
+              <p className="text-sm md:text-base text-muted-foreground font-sans break-words">
+                요청하신 페이지가 존재하지 않거나 이동되었습니다.
+              </p>
+            </div>
+
+            <div className="bg-muted rounded-lg p-3 inline-flex items-center justify-center">
+              <p className="text-xs text-muted-foreground font-mono break-all">
+                경로: {currentPath || location.pathname}
+              </p>
+            </div>
           </div>
 
-          {/* 404 메시지 */}
-          <div className="space-y-3">
-            <h1 className="text-4xl md:text-5xl font-bold text-foreground font-display">404</h1>
-            <h2 className="text-lg md:text-xl font-semibold text-foreground font-display">
-              페이지를 찾을 수 없습니다
-            </h2>
-            <p className="text-sm md:text-base text-muted-foreground font-sans break-words">
-              요청하신 페이지가 존재하지 않거나 이동되었습니다.
-            </p>
+          <div className="grid gap-6">
+            <div className="grid gap-3">
+              <div className="grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
+                <div className="text-left">
+                  <h3 className="text-base font-semibold text-foreground">빠른 탐색</h3>
+                  <p className="text-sm text-muted-foreground">
+                    찾으시는 기능이나 페이지를 검색해 보세요.
+                  </p>
+                </div>
+                <div className="hidden sm:flex gap-2">
+                  <Button onClick={handleGoHome} size="sm">
+                    <Home className="w-4 h-4 mr-2" />
+                    홈으로 이동
+                  </Button>
+                  <Button onClick={handleGoBack} variant="outline" size="sm">
+                    <ArrowLeft className="w-4 h-4 mr-2" />
+                    이전 페이지
+                  </Button>
+                </div>
+              </div>
+
+              <form onSubmit={handleSearchSubmit} className="space-y-2">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={searchTerm}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    placeholder="메뉴, 기능 또는 페이지명을 입력하세요"
+                    className="pl-9"
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground text-left">
+                  Enter 키를 눌러 가장 적합한 페이지로 이동합니다.
+                </p>
+              </form>
+
+              <div className="grid gap-2">
+                <h4 className="text-sm font-semibold text-foreground">최근 방문 페이지</h4>
+                {recentPages.length > 0 ? (
+                  <div className="grid gap-2">
+                    {recentPages.map((path) => (
+                      <Button
+                        key={path}
+                        variant="outline"
+                        className="justify-between text-left"
+                        onClick={() => navigate(path)}
+                      >
+                        <span className="font-medium text-sm">{getRecentPageLabel(path)}</span>
+                        <span className="ml-4 text-xs text-muted-foreground truncate max-w-[12rem]">
+                          {path}
+                        </span>
+                      </Button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    아직 방문 기록이 없습니다. 홈으로 이동해 탐색을 시작해 보세요.
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="grid gap-3">
+              <h4 className="text-sm font-semibold text-foreground">주요 기능 바로가기</h4>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {filteredQuickLinks.length > 0 ? (
+                  filteredQuickLinks.map((link) => {
+                    const Icon = link.icon;
+                    return (
+                      <Button
+                        key={link.path}
+                        variant="secondary"
+                        className="justify-start text-left h-auto py-3"
+                        onClick={() => navigate(link.path)}
+                      >
+                        <Icon className="w-4 h-4 mr-3 text-primary" />
+                        <div className="flex flex-col items-start">
+                          <span className="text-sm font-semibold text-foreground">
+                            {link.title}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {link.description}
+                          </span>
+                        </div>
+                      </Button>
+                    );
+                  })
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    검색어와 일치하는 기능을 찾을 수 없습니다. 다른 검색어를 시도해 보세요.
+                  </p>
+                )}
+              </div>
+            </div>
           </div>
 
-          {/* 요청된 경로 표시 */}
-          <div className="bg-muted rounded-lg p-3">
-            <p className="text-xs text-muted-foreground font-mono break-all">
-              경로: {location.pathname}
-            </p>
-          </div>
-
-          {/* 액션 버튼들 */}
-          <div className="space-y-3">
-            <Button 
-              onClick={handleGoHome}
-              className="w-full font-sans"
-              size="lg"
-            >
-              <Home className="w-4 h-4 mr-2" />
-              {location.pathname.includes('/dashboard') ? '대시보드로 돌아가기' : '메인 페이지로 이동'}
-            </Button>
-            
-            <Button 
-              onClick={handleGoBack}
-              variant="outline"
-              className="w-full font-sans"
-              size="lg"
-            >
-              <ArrowLeft className="w-4 h-4 mr-2" />
-              이전 페이지로
-            </Button>
-          </div>
-
-          {/* 도움말 텍스트 */}
-          <div className="text-center pt-4 border-t">
-            <p className="text-xs text-muted-foreground font-sans">
-              문제가 지속되면 관리자에게 문의하세요.
-            </p>
-          </div>
+          <SupportContactInfo
+            adminEmail={DEFAULT_ADMIN_EMAIL}
+            surveyContact={DEFAULT_SURVEY_CONTACT}
+            className="border-dashed"
+          />
         </CardContent>
       </Card>
     </div>

--- a/src/pages/ShortUrlRedirect.tsx
+++ b/src/pages/ShortUrlRedirect.tsx
@@ -1,7 +1,21 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { AlertTriangle } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import LoadingScreen from '@/components/LoadingScreen';
+import SupportContactInfo, {
+  DEFAULT_ADMIN_EMAIL,
+  DEFAULT_SURVEY_CONTACT,
+} from '@/components/SupportContactInfo';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 
 const ShortUrlRedirect = () => {
   const { shortCode } = useParams<{ shortCode: string }>();
@@ -88,19 +102,37 @@ const ShortUrlRedirect = () => {
   }
 
   if (error) {
+    const handleClose = () => navigate('/');
+
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <div className="text-center space-y-4">
-          <div className="text-4xl">❌</div>
-          <h1 className="text-2xl font-bold">링크 오류</h1>
-          <p className="text-muted-foreground">{error}</p>
-          <button 
-            onClick={() => navigate('/')}
-            className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
-          >
-            홈으로 돌아가기
-          </button>
-        </div>
+      <div className="min-h-screen bg-background">
+        <Dialog open onOpenChange={(open) => !open && handleClose()}>
+          <DialogContent className="sm:max-w-md space-y-6">
+            <div className="flex flex-col items-center space-y-4 text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+                <AlertTriangle className="h-6 w-6 text-destructive" />
+              </div>
+              <DialogHeader className="space-y-2 text-center">
+                <DialogTitle className="text-xl font-semibold">링크 오류</DialogTitle>
+                <DialogDescription className="text-sm text-muted-foreground">
+                  {error}
+                </DialogDescription>
+              </DialogHeader>
+            </div>
+
+            <SupportContactInfo
+              adminEmail={DEFAULT_ADMIN_EMAIL}
+              surveyContact={DEFAULT_SURVEY_CONTACT}
+              className="border-0 bg-muted/20"
+            />
+
+            <DialogFooter className="sm:justify-center">
+              <Button onClick={handleClose} className="w-full sm:w-auto">
+                홈으로 돌아가기
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- add a reusable `SupportContactInfo` component for administrator and survey contacts
- show a contact-aware error dialog in the short URL redirect page when a link is invalid or expired
- enrich the 404 page with search, recent visits, quick links, and shared contact guidance while tracking navigation history in session storage

## Testing
- npm run lint *(fails: missing @eslint/js package due to restricted npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb307a08c8324a8fa7150aad1baad