### PR TITLE
feat: align survey preview with live participation UI

### DIFF
--- a/src/components/InstructorInfoSection.tsx
+++ b/src/components/InstructorInfoSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { User } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 interface Instructor {
   id: string;
@@ -14,18 +15,20 @@ interface Instructor {
 interface InstructorInfoSectionProps {
   instructor: Instructor | null;
   title?: string;
+  className?: string;
 }
 
-export const InstructorInfoSection: React.FC<InstructorInfoSectionProps> = ({ 
-  instructor, 
-  title = "강사 정보" 
+export const InstructorInfoSection: React.FC<InstructorInfoSectionProps> = ({
+  instructor,
+  title = "강사 정보",
+  className,
 }) => {
   if (!instructor) {
     return null;
   }
 
   return (
-    <Card className="mb-6 border-primary/20">
+    <Card className={cn("mb-6 border-primary/20", className)}>
       <CardHeader className="pb-4">
         <CardTitle className="text-lg font-semibold text-primary">
           {title}


### PR DESCRIPTION
## Summary
- add a sticky instructor/session side panel to the survey preview
- mirror the live participation layout and navigation for preview questions and progress
- enhance survey link sharing with clipboard capability feedback and a re-copy option
- allow the instructor info section to receive custom styling overrides

## Testing
- npm run lint *(fails: missing @eslint/js dependency and registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb32b57648324be945bbf9ae3a851