### PR TITLE
refactor: align dashboard shell theming

### DIFF
--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
 import { Button } from '@/components/ui/button'
-import { SidebarTrigger } from '@/components/ui/sidebar'
+import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
 import { AdminSidebar } from './AdminSidebar'
 import { BarChart, Activity, Home, LogOut } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -18,102 +18,102 @@ export function DashboardLayout({ children, title, description }: DashboardLayou
   const navigate = useNavigate()
 
   return (
-    <div className="min-h-screen flex w-full bg-background overflow-x-hidden sidebar-purple">
-      <div className="sidebar-purple">
+    <SidebarProvider>
+      <div className="min-h-screen flex w-full bg-background text-foreground overflow-x-hidden">
         <AdminSidebar />
-      </div>
-      
-      <div className="flex-1 flex flex-col min-w-0 scrollable-y">
-        {/* Header - 더 컴팩트하게 */}
-        <header className="h-12 border-b bg-white/95 backdrop-blur-sm sticky top-0 z-50 shadow-sm ios-safe-area">
-          <div className="flex items-center h-full px-2 sm:px-3 max-w-full overflow-hidden">
-            {/* Left: Sidebar Toggle */}
-            <div className="flex items-center shrink-0">
-              <SidebarTrigger className="h-7 w-7 p-1 mr-2" />
-            </div>
 
-            {/* Center: Page Title */}
-            <div className="flex-1 text-center min-w-0 px-1">
-              <div className="flex items-center justify-center gap-2">
-                <div className="h-5 w-5 sm:h-6 sm:w-6 bg-gradient-to-r from-purple-500 to-indigo-500 rounded-lg flex items-center justify-center shadow-lg shrink-0">
-                  <BarChart className="h-3 w-3 sm:h-3.5 sm:w-3.5 text-white" />
-                </div>
-                <h1 className="text-xs sm:text-sm md:text-base font-bold bg-gradient-to-r from-purple-600 to-indigo-600 bg-clip-text text-transparent break-words leading-tight line-clamp-1 font-display">
-                  {title}
-                </h1>
+        <div className="flex-1 flex flex-col min-w-0 scrollable-y">
+          {/* Header - 더 컴팩트하게 */}
+          <header className="h-12 border-b border-surface-border bg-surface/90 backdrop-blur-sm supports-[backdrop-filter]:bg-surface/80 sticky top-0 z-50 shadow-sm ios-safe-area transition-colors">
+            <div className="flex items-center h-full px-2 sm:px-3 max-w-full overflow-hidden">
+              {/* Left: Sidebar Toggle */}
+              <div className="flex items-center shrink-0">
+                <SidebarTrigger className="h-8 w-8 p-1 mr-2 sm:mr-3" />
               </div>
-              {description && (
-                <p className="text-xs text-muted-foreground break-words line-clamp-1 mt-0.5 hidden sm:block font-sans">
-                  {description}
-                </p>
-              )}
-            </div>
 
-            {/* Right: User Actions */}
-            <div className="flex items-center space-x-1 shrink-0">
-              {/* User Email - Only on larger screens */}
-              <span className="hidden lg:block text-xs text-muted-foreground max-w-20 truncate font-sans">
-                {user?.email}
-              </span>
-
-              {/* Student View Button */}
-              <Button
-                onClick={() => navigate('/')}
-                variant="outline"
-                size="sm"
-                className="h-7 px-2 hidden md:inline-flex text-xs"
-                title="교육생 화면"
-              >
-                <Home className="h-3 w-3 sm:mr-1" />
-                <span className="hidden lg:inline font-sans">교육생</span>
-              </Button>
-
-              {/* Activity Popover */}
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" className="h-7 w-7 p-0">
-                    <Activity className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="end" className="w-64 sm:w-72">
-                  <div className="space-y-3">
-                    <div className="flex items-center gap-2">
-                      <Activity className="h-4 w-4" />
-                      <h3 className="font-semibold text-sm font-display">최근 활동</h3>
-                    </div>
-                    <div className="space-y-2">
-                      <div className="flex justify-between items-center">
-                        <span className="text-sm text-muted-foreground font-sans">시스템 상태</span>
-                        <span className="text-sm text-green-600 font-medium font-sans">정상</span>
-                      </div>
-                      <div className="text-xs text-muted-foreground font-sans">
-                        사용자 역할: {userRoles.join(', ')}
-                      </div>
-                    </div>
+              {/* Center: Page Title */}
+              <div className="flex-1 text-center min-w-0 px-1">
+                <div className="flex items-center justify-center gap-2">
+                  <div className="h-5 w-5 sm:h-6 sm:w-6 bg-gradient-to-r from-primary to-primary/80 rounded-lg flex items-center justify-center shadow-lg shrink-0">
+                    <BarChart className="h-3 w-3 sm:h-3.5 sm:w-3.5 text-primary-foreground" />
                   </div>
-                </PopoverContent>
-              </Popover>
+                  <h1 className="text-xs sm:text-sm md:text-base font-bold bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent break-words leading-tight line-clamp-1 font-display">
+                    {title}
+                  </h1>
+                </div>
+                {description && (
+                  <p className="text-xs text-muted-foreground break-words line-clamp-1 mt-0.5 hidden sm:block font-sans">
+                    {description}
+                  </p>
+                )}
+              </div>
 
-              {/* Logout Button */}
-              <Button
-                onClick={signOut}
-                variant="ghost"
-                size="sm"
-                className="h-7 w-7 p-0"
-              >
-                <LogOut className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-              </Button>
+              {/* Right: User Actions */}
+              <div className="flex items-center space-x-1 shrink-0">
+                {/* User Email - Only on larger screens */}
+                <span className="hidden lg:block text-xs text-muted-foreground max-w-20 truncate font-sans">
+                  {user?.email}
+                </span>
+
+                {/* Student View Button */}
+                <Button
+                  onClick={() => navigate('/')}
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2 hidden md:inline-flex text-xs"
+                  title="교육생 화면"
+                >
+                  <Home className="h-3 w-3 sm:mr-1" />
+                  <span className="hidden lg:inline font-sans">교육생</span>
+                </Button>
+
+                {/* Activity Popover */}
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-7 w-7 p-0">
+                      <Activity className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent align="end" className="w-64 sm:w-72">
+                    <div className="space-y-3">
+                      <div className="flex items-center gap-2">
+                        <Activity className="h-4 w-4" />
+                        <h3 className="font-semibold text-sm font-display">최근 활동</h3>
+                      </div>
+                      <div className="space-y-2">
+                        <div className="flex justify-between items-center">
+                          <span className="text-sm text-muted-foreground font-sans">시스템 상태</span>
+                          <span className="text-sm font-medium font-sans text-[hsl(var(--chart-success))]">정상</span>
+                        </div>
+                        <div className="text-xs text-muted-foreground font-sans">
+                          사용자 역할: {userRoles.join(', ')}
+                        </div>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+
+                {/* Logout Button */}
+                <Button
+                  onClick={signOut}
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 w-7 p-0"
+                >
+                  <LogOut className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                </Button>
+              </div>
             </div>
-          </div>
-        </header>
+          </header>
 
-        {/* Main content - 컴팩트한 패딩 */}
-        <main className="flex-1 p-2 sm:p-3 md:p-4 touch-scroll safe-bottom compact-content">
-          <div className="max-w-full overflow-hidden">
-            {children}
-          </div>
-        </main>
+          {/* Main content - 컴팩트한 패딩 */}
+          <main className="flex-1 p-2 sm:p-3 md:p-4 touch-scroll safe-bottom compact-content">
+            <div className="max-w-full overflow-hidden">
+              {children}
+            </div>
+          </main>
+        </div>
       </div>
-    </div>
+    </SidebarProvider>
   )
 }

--- a/src/components/layouts/PageHeader.tsx
+++ b/src/components/layouts/PageHeader.tsx
@@ -15,12 +15,12 @@ export function PageHeader({ title, subtitle, icon }: PageHeaderProps) {
   const { user, signOut } = useAuth();
 
   return (
-    <header className="border-b bg-white/95 backdrop-blur-sm sticky top-0 z-40 shadow-sm">
+    <header className="border-b border-surface-border bg-surface/90 supports-[backdrop-filter]:bg-surface/80 backdrop-blur-sm sticky top-0 z-40 shadow-sm transition-colors">
       <div className="container mx-auto px-4 py-3 md:py-4 flex justify-between items-center">
         <div className="flex items-center gap-3">
-          <SidebarTrigger />
+          <SidebarTrigger className="h-9 w-9" />
           <div className="h-10 w-10 bg-gradient-to-br from-primary to-primary/80 rounded-xl flex items-center justify-center shadow-lg">
-            {icon || <BarChart3 className="h-5 w-5 text-white" />}
+            {icon || <BarChart3 className="h-5 w-5 text-primary-foreground" />}
           </div>
           <div>
             <h1 className="text-base md:text-2xl font-bold bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,9 @@ All colors MUST be HSL.
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
     --ring: 263 70% 50.4%;
+    --surface: 0 0% 100%;
+    --surface-foreground: 222.2 84% 4.9%;
+    --surface-border: 214.3 31.8% 91.4%;
 
     /* Modern gradient colors */
     --gradient-primary: linear-gradient(135deg, hsl(263 70% 50.4%) 0%, hsl(270 91% 65%) 100%);
@@ -77,14 +80,14 @@ All colors MUST be HSL.
     --radius: 0.5rem;
 
     /* 사이드바 색상 변수 - 가시성 확보를 위한 명확한 대비 */
-    --sidebar-background: 0 0% 98%;
+    --sidebar-background: var(--surface);
     --sidebar-foreground: 263 70% 40%;
     --sidebar-primary: 263 70% 50.4%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 0 0% 95%;
+    --sidebar-accent: 0 0% 96%;
     --sidebar-accent-foreground: 263 70% 30%;
-    --sidebar-border: 0 0% 90%;
-    --sidebar-ring: 263 70% 50.4%;
+    --sidebar-border: var(--surface-border);
+    --sidebar-ring: var(--primary);
   }
 
   .dark {
@@ -115,14 +118,17 @@ All colors MUST be HSL.
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 217.2 91.2% 59.8%;
-    --sidebar-background: 0 0% 15%;
+    --surface: 220 15% 16%;
+    --surface-foreground: 210 40% 96%;
+    --surface-border: 220 15% 24%;
+    --sidebar-background: var(--surface);
     --sidebar-foreground: 0 0% 85%;
     --sidebar-primary: 263 70% 50.4%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 0 0% 20%;
-    --sidebar-accent-foreground: 0 0% 90%;
-    --sidebar-border: 0 0% 25%;
-    --sidebar-ring: 263 70% 50.4%;
+    --sidebar-accent: 220 15% 22%;
+    --sidebar-accent-foreground: 0 0% 98%;
+    --sidebar-border: var(--surface-border);
+    --sidebar-ring: var(--primary);
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -79,14 +79,19 @@ export default {
 					DEFAULT: 'hsl(var(--popover))',
 					foreground: 'hsl(var(--popover-foreground))'
 				},
-				card: {
-					DEFAULT: 'hsl(var(--card))',
-					foreground: 'hsl(var(--card-foreground))'
-				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
+                                card: {
+                                        DEFAULT: 'hsl(var(--card))',
+                                        foreground: 'hsl(var(--card-foreground))'
+                                },
+                                surface: {
+                                        DEFAULT: 'hsl(var(--surface))',
+                                        foreground: 'hsl(var(--surface-foreground))',
+                                        border: 'hsl(var(--surface-border))'
+                                },
+                                sidebar: {
+                                        DEFAULT: 'hsl(var(--sidebar-background))',
+                                        foreground: 'hsl(var(--sidebar-foreground))',
+                                        primary: 'hsl(var(--sidebar-primary))',
 					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
 					accent: 'hsl(var(--sidebar-accent))',
 					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',


### PR DESCRIPTION
## Summary
- wrap the dashboard layout with the shared `SidebarProvider`, update header styling to use theme tokens, and surface the mobile hamburger behaviour
- introduce shared `surface` color variables and map sidebar colors to them so the header and sidebar stay consistent in light and dark themes
- refresh the reusable page header to follow the new tokens for icon, background, and typography accents

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb39f99ac832495bbf626d10e5685