### PR TITLE
Handle empty chart data with shared empty states

### DIFF
--- a/src/components/charts/AreaChart.tsx
+++ b/src/components/charts/AreaChart.tsx
@@ -1,4 +1,15 @@
-import { AreaChart as RechartsAreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { ReactNode, useMemo } from 'react';
+import {
+  AreaChart as RechartsAreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend
+} from 'recharts';
+import { ChartEmptyState } from './ChartEmptyState';
 
 interface AreaChartProps {
   data: Array<{
@@ -14,104 +25,137 @@ interface AreaChartProps {
   xAxisLabel?: string;
   yAxisLabel?: string;
   stacked?: boolean;
+  emptyState?: ReactNode;
 }
 
 const DEFAULT_COLORS = [
   'hsl(var(--chart-1))',
-  'hsl(var(--chart-2))', 
+  'hsl(var(--chart-2))',
   'hsl(var(--chart-3))',
   'hsl(var(--chart-4))',
   'hsl(var(--chart-5))',
   'hsl(var(--chart-purple-light))'
 ];
 
-export const AreaChart = ({ 
-  data, 
+export const AreaChart = ({
+  data,
   dataKeys,
-  title, 
-  xAxisLabel, 
+  title,
+  xAxisLabel,
   yAxisLabel,
-  stacked = false
+  stacked = false,
+  emptyState
 }: AreaChartProps) => {
+  const hasData = useMemo(() => {
+    if (!data || data.length === 0) return false;
+
+    return dataKeys.some(item =>
+      data.some(row => {
+        const value = row[item.key];
+        return typeof value === 'number' && !isNaN(value) && value !== 0;
+      })
+    );
+  }, [data, dataKeys]);
+
   return (
-    <div className="w-full h-full">
+    <div className="h-full w-full">
       {title && (
-        <h3 className="text-center font-semibold mb-4 text-foreground">{title}</h3>
+        <h3 className="mb-4 text-center font-semibold text-foreground">{title}</h3>
       )}
-      <ResponsiveContainer width="100%" height="100%">
-        <RechartsAreaChart
-          data={data}
-          margin={{
-            top: 10,
-            right: 30,
-            left: 20,
-            bottom: 5,
-          }}
-        >
-          <defs>
-            {dataKeys.map((item, index) => (
-              <linearGradient key={`gradient${index}`} id={`gradient${index}`} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor={item.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length]} stopOpacity={0.8}/>
-                <stop offset="100%" stopColor={item.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length]} stopOpacity={0.1}/>
-              </linearGradient>
-            ))}
-          </defs>
-          <CartesianGrid 
-            strokeDasharray="3 3" 
-            stroke="hsl(var(--chart-1) / 0.2)"
-            strokeWidth={1}
-          />
-          <XAxis 
-            dataKey="name"
-            tick={{ fontSize: 12, fill: 'hsl(var(--foreground))' }}
-            axisLine={{ stroke: 'hsl(var(--muted-foreground))' }}
-            label={xAxisLabel ? { 
-              value: xAxisLabel, 
-              position: 'insideBottom', 
-              offset: -5,
-              style: { textAnchor: 'middle', fill: 'hsl(var(--muted-foreground))' }
-            } : undefined}
-          />
-          <YAxis 
-            tick={{ fontSize: 12, fill: 'hsl(var(--foreground))' }}
-            axisLine={{ stroke: 'hsl(var(--muted-foreground))' }}
-            label={yAxisLabel ? {
-              value: yAxisLabel,
-              angle: -90,
-              position: 'insideLeft',
-              style: { textAnchor: 'middle', fill: 'hsl(var(--muted-foreground))' }
-            } : undefined}
-          />
-          <Tooltip 
-            contentStyle={{
-              backgroundColor: 'hsl(var(--card))',
-              border: '1px solid hsl(var(--border))',
-              borderRadius: '8px',
-              color: 'hsl(var(--card-foreground))'
+      {hasData ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <RechartsAreaChart
+            data={data}
+            margin={{
+              top: 10,
+              right: 30,
+              left: 20,
+              bottom: 5
             }}
-          />
-          <Legend 
-            wrapperStyle={{ 
-              fontSize: '12px',
-              color: 'hsl(var(--foreground))'
-            }}
-          />
-          {dataKeys.map((item, index) => (
-            <Area
-              key={item.key}
-              type="monotone"
-              dataKey={item.key}
-              stackId={stacked ? "1" : undefined}
-              stroke={item.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length]}
-              fill={`url(#gradient${index})`}
-              fillOpacity={0.8}
-              strokeWidth={3}
-              name={item.label}
-              dot={{ r: 4, strokeWidth: 2, stroke: 'white' }}
+          >
+            <defs>
+              {dataKeys.map((item, index) => (
+                <linearGradient key={`gradient${index}`} id={`gradient${index}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop
+                    offset="0%"
+                    stopColor={item.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length]}
+                    stopOpacity={0.8}
+                  />
+                  <stop
+                    offset="100%"
+                    stopColor={item.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length]}
+                    stopOpacity={0.1}
+                  />
+                </linearGradient>
+              ))}
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--chart-1) / 0.2)" strokeWidth={1} />
+            <XAxis
+              dataKey="name"
+              tick={{ fontSize: 12, fill: 'hsl(var(--foreground))' }}
+              axisLine={{ stroke: 'hsl(var(--muted-foreground))' }}
+              label={
+                xAxisLabel
+                  ? {
+                      value: xAxisLabel,
+                      position: 'insideBottom',
+                      offset: -5,
+                      style: { textAnchor: 'middle', fill: 'hsl(var(--muted-foreground))' }
+                    }
+                  : undefined
+              }
             />
-          ))}
-        </RechartsAreaChart>
-      </ResponsiveContainer>
+            <YAxis
+              tick={{ fontSize: 12, fill: 'hsl(var(--foreground))' }}
+              axisLine={{ stroke: 'hsl(var(--muted-foreground))' }}
+              label={
+                yAxisLabel
+                  ? {
+                      value: yAxisLabel,
+                      angle: -90,
+                      position: 'insideLeft',
+                      style: { textAnchor: 'middle', fill: 'hsl(var(--muted-foreground))' }
+                    }
+                  : undefined
+              }
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--card))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '8px',
+                color: 'hsl(var(--card-foreground))'
+              }}
+            />
+            <Legend
+              wrapperStyle={{
+                fontSize: '12px',
+                color: 'hsl(var(--foreground))'
+              }}
+            />
+            {dataKeys.map((item, index) => (
+              <Area
+                key={item.key}
+                type="monotone"
+                dataKey={item.key}
+                stackId={stacked ? '1' : undefined}
+                stroke={item.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length]}
+                fill={`url(#gradient${index})`}
+                fillOpacity={0.8}
+                strokeWidth={3}
+                name={item.label}
+                dot={{ r: 4, strokeWidth: 2, stroke: 'white' }}
+              />
+            ))}
+          </RechartsAreaChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-64 w-full items-center justify-center">
+          {emptyState ?? (
+            <ChartEmptyState description="데이터가 없어 영역 차트를 표시할 수 없습니다. 조건을 변경하거나 데이터를 수집한 후 다시 시도하세요." />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/charts/ChartEmptyState.tsx
+++ b/src/components/charts/ChartEmptyState.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from 'react';
+
+interface ChartEmptyStateProps {
+  title?: string;
+  description?: string;
+  actions?: ReactNode;
+}
+
+export const ChartEmptyState = ({
+  title = 'No data',
+  description = '표시할 데이터가 없습니다.',
+  actions
+}: ChartEmptyStateProps) => {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 py-10 text-center">
+      <div className="rounded-full border border-dashed border-border/60 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <p className="max-w-sm text-sm text-muted-foreground">
+        {description}
+      </p>
+      {actions && <div className="text-sm text-muted-foreground">{actions}</div>}
+    </div>
+  );
+};

--- a/src/components/charts/DonutChart.tsx
+++ b/src/components/charts/DonutChart.tsx
@@ -1,46 +1,59 @@
+import { ReactNode, useMemo } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { ChartEmptyState } from './ChartEmptyState';
 
 interface DonutChartProps {
   data: Array<{ name: string; value: number; color?: string }>;
   title?: string;
   innerRadius?: number;
   outerRadius?: number;
+  emptyState?: ReactNode;
 }
 
 const COLORS = [
-  'hsl(var(--chart-1))', 
-  'hsl(var(--chart-2))', 
-  'hsl(var(--chart-3))', 
-  'hsl(var(--chart-4))', 
-  'hsl(var(--chart-5))', 
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
   'hsl(var(--chart-purple-light))',
   'hsl(var(--chart-purple-dark))'
 ];
 
-export const DonutChart = ({ 
-  data, 
-  title, 
-  innerRadius = 60, 
-  outerRadius = 100 
+export const DonutChart = ({
+  data,
+  title,
+  innerRadius = 60,
+  outerRadius = 100,
+  emptyState
 }: DonutChartProps) => {
-  const dataWithColors = data.map((item, index) => ({
-    ...item,
-    color: item.color || COLORS[index % COLORS.length]
-  }));
+  const dataWithColors = useMemo(
+    () =>
+      data.map((item, index) => ({
+        ...item,
+        color: item.color || COLORS[index % COLORS.length]
+      })),
+    [data]
+  );
 
-  const renderLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }: any) => {
+  const hasData = useMemo(
+    () => dataWithColors.length > 0 && dataWithColors.some(item => item.value > 0),
+    [dataWithColors]
+  );
+
+  const renderLabel = ({ cx, cy, midAngle, innerRadius: inner, outerRadius: outer, percent }: any) => {
     const RADIAN = Math.PI / 180;
-    const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+    const radius = inner + (outer - inner) * 0.5;
     const x = cx + radius * Math.cos(-midAngle * RADIAN);
     const y = cy + radius * Math.sin(-midAngle * RADIAN);
 
-    if (percent > 0.05) { // 5% 이상만 라벨 표시
+    if (percent > 0.05) {
       return (
-        <text 
-          x={x} 
-          y={y} 
-          fill="white" 
-          textAnchor={x > cx ? 'start' : 'end'} 
+        <text
+          x={x}
+          y={y}
+          fill="white"
+          textAnchor={x > cx ? 'start' : 'end'}
           dominantBaseline="central"
           fontSize="12"
           fontWeight="bold"
@@ -53,47 +66,56 @@ export const DonutChart = ({
   };
 
   return (
-    <div className="w-full h-full">
+    <div className="h-full w-full">
       {title && (
-        <h3 className="text-center font-semibold mb-4 text-foreground">{title}</h3>
+        <h3 className="mb-4 text-center font-semibold text-foreground">{title}</h3>
       )}
-      <ResponsiveContainer width="100%" height="100%">
-        <PieChart>
-          <Pie
-            data={dataWithColors}
-            cx="50%"
-            cy="50%"
-            labelLine={false}
-            label={renderLabel}
-            outerRadius={outerRadius}
-            innerRadius={innerRadius}
-            fill="#8884d8"
-            dataKey="value"
-            stroke="white"
-            strokeWidth={2}
-            cornerRadius={3}
-          >
-            {dataWithColors.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.color} />
-            ))}
-          </Pie>
-          <Tooltip 
-            formatter={(value: number, name: string) => [value, name]}
-            contentStyle={{
-              backgroundColor: 'hsl(var(--card))',
-              border: '1px solid hsl(var(--border))',
-              borderRadius: '8px',
-              color: 'hsl(var(--card-foreground))'
-            }}
-          />
-          <Legend 
-            wrapperStyle={{ 
-              fontSize: '12px',
-              color: 'hsl(var(--foreground))'
-            }}
-          />
-        </PieChart>
-      </ResponsiveContainer>
+
+      {hasData ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={dataWithColors}
+              cx="50%"
+              cy="50%"
+              labelLine={false}
+              label={renderLabel}
+              outerRadius={outerRadius}
+              innerRadius={innerRadius}
+              fill="#8884d8"
+              dataKey="value"
+              stroke="white"
+              strokeWidth={2}
+              cornerRadius={3}
+            >
+              {dataWithColors.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value: number, name: string) => [value, name]}
+              contentStyle={{
+                backgroundColor: 'hsl(var(--card))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '8px',
+                color: 'hsl(var(--card-foreground))'
+              }}
+            />
+            <Legend
+              wrapperStyle={{
+                fontSize: '12px',
+                color: 'hsl(var(--foreground))'
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-64 w-full items-center justify-center">
+          {emptyState ?? (
+            <ChartEmptyState description="데이터가 없어 원형 차트를 표시할 수 없습니다. 다른 조건을 선택하거나 데이터를 수집한 후 다시 확인해 주세요." />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/charts/HeatmapChart.tsx
+++ b/src/components/charts/HeatmapChart.tsx
@@ -1,4 +1,6 @@
-import { ResponsiveContainer, Cell } from 'recharts';
+import { ReactNode, useMemo } from 'react';
+import { ResponsiveContainer } from 'recharts';
+import { ChartEmptyState } from './ChartEmptyState';
 
 interface HeatmapData {
   x: string;
@@ -12,161 +14,161 @@ interface HeatmapChartProps {
   title?: string;
   xAxisLabel?: string;
   yAxisLabel?: string;
-  colorScale?: [string, string]; // [minColor, maxColor]
+  colorScale?: [string, string];
+  emptyState?: ReactNode;
 }
 
-export const HeatmapChart = ({ 
-  data, 
-  title, 
-  xAxisLabel, 
+const parseHSL = (hslString: string) => {
+  const match = hslString.match(/hsl\(var\(--(\w+)\)\)/);
+  if (match) {
+    return { h: 210, s: 50, l: 50 };
+  }
+
+  const values = hslString.match(/\d+/g);
+  if (values && values.length >= 3) {
+    return {
+      h: parseInt(values[0]),
+      s: parseInt(values[1]),
+      l: parseInt(values[2])
+    };
+  }
+  return { h: 210, s: 50, l: 50 };
+};
+
+export const HeatmapChart = ({
+  data,
+  title,
+  xAxisLabel,
   yAxisLabel,
-  colorScale = ['hsl(var(--muted) / 0.3)', 'hsl(var(--chart-1))']
+  colorScale = ['hsl(var(--muted) / 0.3)', 'hsl(var(--chart-1))'],
+  emptyState
 }: HeatmapChartProps) => {
-  // 데이터에서 고유한 x, y 값들 추출
-  const xValues = [...new Set(data.map(d => d.x))];
-  const yValues = [...new Set(data.map(d => d.y))];
-  
-  // 최대/최소값 계산
-  const maxValue = Math.max(...data.map(d => d.value));
-  const minValue = Math.min(...data.map(d => d.value));
-  
-  // 색상 계산 함수
+  const hasData = useMemo(
+    () => data && data.length > 0 && data.some(item => item.value !== 0),
+    [data]
+  );
+
+  const xValues = useMemo(() => [...new Set(data.map(d => d.x))], [data]);
+  const yValues = useMemo(() => [...new Set(data.map(d => d.y))], [data]);
+
+  const maxValue = useMemo(() => (data.length > 0 ? Math.max(...data.map(d => d.value)) : 0), [data]);
+  const minValue = useMemo(() => (data.length > 0 ? Math.min(...data.map(d => d.value)) : 0), [data]);
+
   const getColor = (value: number) => {
     if (maxValue === minValue) return colorScale[0];
     const intensity = (value - minValue) / (maxValue - minValue);
-    
-    // HSL 색상 보간
+
     const minHSL = parseHSL(colorScale[0]);
     const maxHSL = parseHSL(colorScale[1]);
-    
+
     const h = minHSL.h + (maxHSL.h - minHSL.h) * intensity;
     const s = minHSL.s + (maxHSL.s - minHSL.s) * intensity;
     const l = minHSL.l + (maxHSL.l - minHSL.l) * intensity;
-    
+
     return `hsl(${h}, ${s}%, ${l}%)`;
   };
-  
-  // HSL 파싱 함수
-  const parseHSL = (hslString: string) => {
-    const match = hslString.match(/hsl\(var\(--(\w+)\)\)/);
-    if (match) {
-      // CSS 변수 기반인 경우 기본값 사용
-      return { h: 210, s: 50, l: 50 };
-    }
-    
-    const values = hslString.match(/\d+/g);
-    if (values && values.length >= 3) {
-      return {
-        h: parseInt(values[0]),
-        s: parseInt(values[1]),
-        l: parseInt(values[2])
-      };
-    }
-    return { h: 210, s: 50, l: 50 };
-  };
-  
-  // 셀 크기 계산
-  const cellWidth = 100 / xValues.length;
-  const cellHeight = 100 / yValues.length;
+
+  const cellWidth = xValues.length > 0 ? 100 / xValues.length : 0;
+  const cellHeight = yValues.length > 0 ? 100 / yValues.length : 0;
 
   return (
-    <div className="w-full h-full">
+    <div className="h-full w-full">
       {title && (
-        <h3 className="text-center font-semibold mb-4 text-foreground">{title}</h3>
+        <h3 className="mb-4 text-center font-semibold text-foreground">{title}</h3>
       )}
-      
-      <div className="relative w-full h-full min-h-[300px]">
-        {/* Y축 라벨 */}
-        {yAxisLabel && (
-          <div className="absolute left-0 top-1/2 transform -translate-y-1/2 -rotate-90">
-            <span className="text-sm font-medium text-muted-foreground">{yAxisLabel}</span>
-          </div>
-        )}
-        
-        {/* 메인 차트 영역 */}
-        <div className="ml-8 mb-8 h-full">
-          <div className="relative w-full h-full">
-            {/* Y축 값들 */}
-            <div className="absolute left-0 top-0 h-full flex flex-col justify-between pr-2">
-              {yValues.map(y => (
-                <div key={y} className="text-xs text-muted-foreground flex items-center h-full">
-                  {y}
-                </div>
-              ))}
+
+      {hasData ? (
+        <div className="relative h-full w-full min-h-[300px]">
+          {yAxisLabel && (
+            <div className="absolute left-0 top-1/2 -translate-y-1/2 -rotate-90 transform">
+              <span className="text-sm font-medium text-muted-foreground">{yAxisLabel}</span>
             </div>
-            
-            {/* 히트맵 그리드 */}
-            <div className="ml-12 h-full">
-              <svg width="100%" height="80%" viewBox="0 0 100 100" className="border border-border rounded">
-                {data.map((item, index) => {
-                  const xIndex = xValues.indexOf(item.x);
-                  const yIndex = yValues.indexOf(item.y);
-                  
-                  return (
-                    <g key={index}>
-                      <rect
-                        x={xIndex * cellWidth}
-                        y={yIndex * cellHeight}
-                        width={cellWidth}
-                        height={cellHeight}
-                        fill={getColor(item.value)}
-                        stroke="white"
-                        strokeWidth="0.5"
-                        rx="1"
-                        ry="1"
-                        className="hover:opacity-80 transition-all duration-200 cursor-pointer hover:stroke-2"
-                      />
-                      {/* 값 표시 */}
-                      <text
-                        x={xIndex * cellWidth + cellWidth / 2}
-                        y={yIndex * cellHeight + cellHeight / 2}
-                        textAnchor="middle"
-                        dominantBaseline="middle"
-                        fontSize="3"
-                        fill="white"
-                        fontWeight="bold"
-                      >
-                        {item.label || item.value}
-                      </text>
-                    </g>
-                  );
-                })}
-              </svg>
-              
-              {/* X축 값들 */}
-              <div className="flex justify-between mt-2">
-                {xValues.map(x => (
-                  <div key={x} className="text-xs text-muted-foreground text-center flex-1">
-                    {x}
+          )}
+
+          <div className="ml-8 mb-8 h-full">
+            <div className="relative h-full w-full">
+              <div className="absolute left-0 top-0 flex h-full flex-col justify-between pr-2">
+                {yValues.map(y => (
+                  <div key={y} className="flex h-full items-center text-xs text-muted-foreground">
+                    {y}
                   </div>
                 ))}
               </div>
+
+              <div className="ml-12 h-full">
+                <ResponsiveContainer width="100%" height="100%">
+                  <svg viewBox="0 0 100 100" className="h-full w-full rounded border border-border">
+                    {data.map((item, index) => {
+                      const xIndex = xValues.indexOf(item.x);
+                      const yIndex = yValues.indexOf(item.y);
+
+                      return (
+                        <g key={index}>
+                          <rect
+                            x={xIndex * cellWidth}
+                            y={yIndex * cellHeight}
+                            width={cellWidth}
+                            height={cellHeight}
+                            fill={getColor(item.value)}
+                            stroke="white"
+                            strokeWidth="0.5"
+                            rx="1"
+                            ry="1"
+                            className="cursor-pointer transition-all duration-200 hover:stroke-2 hover:opacity-80"
+                          />
+                          <text
+                            x={xIndex * cellWidth + cellWidth / 2}
+                            y={yIndex * cellHeight + cellHeight / 2}
+                            textAnchor="middle"
+                            dominantBaseline="middle"
+                            fontSize="3"
+                            fill="white"
+                            fontWeight="bold"
+                          >
+                            {item.label || item.value}
+                          </text>
+                        </g>
+                      );
+                    })}
+                  </svg>
+                </ResponsiveContainer>
+
+                <div className="mt-2 flex justify-between">
+                  {xValues.map(x => (
+                    <div key={x} className="flex-1 text-center text-xs text-muted-foreground">
+                      {x}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {xAxisLabel && (
+            <div className="absolute bottom-0 left-1/2 -translate-x-1/2 transform">
+              <span className="text-sm font-medium text-muted-foreground">{xAxisLabel}</span>
+            </div>
+          )}
+
+          <div className="absolute right-0 top-0 flex flex-col items-center">
+            <div className="mb-1 text-xs text-muted-foreground">값</div>
+            <div className="flex flex-col items-center">
+              <div className="text-xs text-muted-foreground">{maxValue}</div>
+              <div
+                className="h-12 w-4 rounded"
+                style={{ background: `linear-gradient(to top, ${colorScale[0]}, ${colorScale[1]})` }}
+              />
+              <div className="text-xs text-muted-foreground">{minValue}</div>
             </div>
           </div>
         </div>
-        
-        {/* X축 라벨 */}
-        {xAxisLabel && (
-          <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2">
-            <span className="text-sm font-medium text-muted-foreground">{xAxisLabel}</span>
-          </div>
-        )}
-        
-        {/* 범례 */}
-        <div className="absolute top-0 right-0 flex flex-col items-center">
-          <div className="text-xs text-muted-foreground mb-1">값</div>
-          <div className="flex flex-col items-center">
-            <div className="text-xs text-muted-foreground">{maxValue}</div>
-            <div 
-              className="w-4 h-12 rounded"
-              style={{
-                background: `linear-gradient(to top, ${colorScale[0]}, ${colorScale[1]})`
-              }}
-            />
-            <div className="text-xs text-muted-foreground">{minValue}</div>
-          </div>
+      ) : (
+        <div className="flex h-64 w-full items-center justify-center">
+          {emptyState ?? (
+            <ChartEmptyState description="히트맵을 표시할 데이터가 없습니다. 필터를 변경하거나 데이터를 수집한 후 다시 확인해 주세요." />
+          )}
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/charts/RadarChart.tsx
+++ b/src/components/charts/RadarChart.tsx
@@ -1,4 +1,14 @@
-import { Radar, RadarChart as RechartsRadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { ReactNode, useMemo } from 'react';
+import {
+  Radar,
+  RadarChart as RechartsRadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Tooltip
+} from 'recharts';
+import { ChartEmptyState } from './ChartEmptyState';
 
 interface RadarChartProps {
   data: Array<{
@@ -11,69 +21,81 @@ interface RadarChartProps {
     fill?: string;
     stroke?: string;
   };
+  emptyState?: ReactNode;
 }
 
-export const RadarChart = ({ 
-  data, 
+export const RadarChart = ({
+  data,
   title,
   colors = {
     fill: 'hsl(var(--chart-1) / 0.3)',
     stroke: 'hsl(var(--chart-1))'
-  }
+  },
+  emptyState
 }: RadarChartProps) => {
+  const hasData = useMemo(
+    () => data && data.length > 0 && data.some(item => Number.isFinite(item.value) && item.value !== 0),
+    [data]
+  );
+
   return (
-    <div className="w-full h-full">
+    <div className="h-full w-full">
       {title && (
-        <h3 className="text-center font-semibold mb-4 text-foreground">{title}</h3>
+        <h3 className="mb-4 text-center font-semibold text-foreground">{title}</h3>
       )}
-      <ResponsiveContainer width="100%" height="100%">
-        <RechartsRadarChart data={data} margin={{ top: 20, right: 80, bottom: 20, left: 80 }}>
-          <PolarGrid 
-            stroke="hsl(var(--chart-1) / 0.2)"
-            strokeWidth={1}
-            radialLines={true}
-          />
-          <PolarAngleAxis 
-            dataKey="subject" 
-            tick={{ 
-              fontSize: 12, 
-              fill: 'hsl(var(--foreground))',
-              fontWeight: 500
-            }}
-            tickLine={false}
-            axisLine={false}
-          />
-          <PolarRadiusAxis 
-            angle={90}
-            domain={[0, 10]}
-            tick={{ 
-              fontSize: 10, 
-              fill: 'hsl(var(--muted-foreground))',
-              fontWeight: 400
-            }}
-            tickLine={false}
-            axisLine={false}
-          />
-          <Radar
-            name="점수"
-            dataKey="value"
-            stroke={colors.stroke}
-            fill={colors.fill}
-            fillOpacity={0.4}
-            strokeWidth={3}
-            dot={{ r: 4, fill: colors.stroke, strokeWidth: 2, stroke: 'white' }}
-          />
-          <Tooltip 
-            formatter={(value: number) => [`${value}점`, '점수']}
-            contentStyle={{
-              backgroundColor: 'hsl(var(--card))',
-              border: '1px solid hsl(var(--border))',
-              borderRadius: '8px',
-              color: 'hsl(var(--card-foreground))'
-            }}
-          />
-        </RechartsRadarChart>
-      </ResponsiveContainer>
+
+      {hasData ? (
+        <ResponsiveContainer width="100%" height="100%">
+          <RechartsRadarChart data={data} margin={{ top: 20, right: 80, bottom: 20, left: 80 }}>
+            <PolarGrid stroke="hsl(var(--chart-1) / 0.2)" strokeWidth={1} radialLines />
+            <PolarAngleAxis
+              dataKey="subject"
+              tick={{
+                fontSize: 12,
+                fill: 'hsl(var(--foreground))',
+                fontWeight: 500
+              }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <PolarRadiusAxis
+              angle={90}
+              domain={[0, 10]}
+              tick={{
+                fontSize: 10,
+                fill: 'hsl(var(--muted-foreground))',
+                fontWeight: 400
+              }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <Radar
+              name="점수"
+              dataKey="value"
+              stroke={colors.stroke}
+              fill={colors.fill}
+              fillOpacity={0.4}
+              strokeWidth={3}
+              dot={{ r: 4, fill: colors.stroke, strokeWidth: 2, stroke: 'white' }}
+            />
+            <Tooltip
+              formatter={(value: number) => [`${value}점`, '점수']}
+              contentStyle={{
+                backgroundColor: 'hsl(var(--card))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '8px',
+                color: 'hsl(var(--card-foreground))'
+              }}
+            />
+          </RechartsRadarChart>
+        </ResponsiveContainer>
+      ) : (
+        <div className="flex h-64 w-full items-center justify-center">
+          {emptyState ?? (
+            <ChartEmptyState description="데이터가 없어 레이더 차트를 표시할 수 없습니다. 응답을 수집하거나 다른 조건을 선택해 주세요." />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/charts/index.ts
+++ b/src/components/charts/index.ts
@@ -3,3 +3,4 @@ export { HeatmapChart } from './HeatmapChart';
 export { GaugeChart } from './GaugeChart';
 export { RadarChart } from './RadarChart';
 export { AreaChart } from './AreaChart';
+export { ChartEmptyState } from './ChartEmptyState';


### PR DESCRIPTION
## Summary
- add a reusable `ChartEmptyState` component and update all chart wrappers to return it when no values are available
- guard the personal dashboard against missing responses by disabling data-dependent actions, using empty state messaging, and improving guidance in charts
- update the survey analysis question logic to classify empty results and surface the new empty state guidance in the UI

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*
- npm run build *(fails: vite command not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb42944c883249fe5018bd9db8cef