### PR TITLE
feat: server aggregate survey results and background exports

### DIFF
--- a/supabase/migrations/20250921000000_create_survey_aggregates_view.sql
+++ b/supabase/migrations/20250921000000_create_survey_aggregates_view.sql
@@ -1,0 +1,88 @@
+-- Create a view that exposes aggregated survey metrics so the application can avoid
+-- calculating heavy statistics in the client.
+DROP VIEW IF EXISTS public.survey_aggregates;
+
+CREATE VIEW public.survey_aggregates AS
+SELECT
+  s.id AS survey_id,
+  s.title,
+  s.education_year,
+  s.education_round,
+  s.course_name,
+  s.status,
+  s.instructor_id,
+  i.name AS instructor_name,
+  s.expected_participants,
+  s.is_test,
+  COUNT(DISTINCT sr.id) AS response_count,
+  MAX(sr.submitted_at) AS last_response_at,
+  AVG(
+    CASE
+      WHEN qa.answer_value::text ~ '^[0-9]+(\.[0-9]+)?$'
+           AND sq.question_type IN ('scale', 'rating')
+      THEN CASE
+        WHEN (qa.answer_value::text)::numeric <= 5
+          THEN (qa.answer_value::text)::numeric * 2
+        ELSE (qa.answer_value::text)::numeric
+      END
+      ELSE NULL
+    END
+  ) AS avg_overall_satisfaction,
+  AVG(
+    CASE
+      WHEN qa.answer_value::text ~ '^[0-9]+(\.[0-9]+)?$'
+           AND sq.question_type IN ('scale', 'rating')
+           AND sq.satisfaction_type = 'course'
+      THEN CASE
+        WHEN (qa.answer_value::text)::numeric <= 5
+          THEN (qa.answer_value::text)::numeric * 2
+        ELSE (qa.answer_value::text)::numeric
+      END
+      ELSE NULL
+    END
+  ) AS avg_course_satisfaction,
+  AVG(
+    CASE
+      WHEN qa.answer_value::text ~ '^[0-9]+(\.[0-9]+)?$'
+           AND sq.question_type IN ('scale', 'rating')
+           AND sq.satisfaction_type = 'instructor'
+      THEN CASE
+        WHEN (qa.answer_value::text)::numeric <= 5
+          THEN (qa.answer_value::text)::numeric * 2
+        ELSE (qa.answer_value::text)::numeric
+      END
+      ELSE NULL
+    END
+  ) AS avg_instructor_satisfaction,
+  AVG(
+    CASE
+      WHEN qa.answer_value::text ~ '^[0-9]+(\.[0-9]+)?$'
+           AND sq.question_type IN ('scale', 'rating')
+           AND sq.satisfaction_type = 'operation'
+      THEN CASE
+        WHEN (qa.answer_value::text)::numeric <= 5
+          THEN (qa.answer_value::text)::numeric * 2
+        ELSE (qa.answer_value::text)::numeric
+      END
+      ELSE NULL
+    END
+  ) AS avg_operation_satisfaction
+FROM public.surveys s
+LEFT JOIN public.instructors i ON i.id = s.instructor_id
+LEFT JOIN public.survey_responses sr ON sr.survey_id = s.id
+LEFT JOIN public.question_answers qa ON qa.response_id = sr.id
+LEFT JOIN public.survey_questions sq ON sq.id = qa.question_id
+WHERE s.status IN ('completed', 'active')
+GROUP BY
+  s.id,
+  s.title,
+  s.education_year,
+  s.education_round,
+  s.course_name,
+  s.status,
+  s.instructor_id,
+  i.name,
+  s.expected_participants,
+  s.is_test;
+
+COMMENT ON VIEW public.survey_aggregates IS 'Aggregated survey metrics including response counts and satisfaction averages';


### PR DESCRIPTION
## Summary
- add a Supabase view that exposes survey response counts and satisfaction averages so aggregation runs on the server
- rebuild the SurveyResults page to consume the server-side aggregates, provide filters, and page through detailed responses
- move CSV exports to a chunked background workflow that reports progress while the download is prepared

## Testing
- npm run lint *(fails: npm 403 Forbidden while downloading tailwindcss dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb43b9f308324af46196e67a971df