### PR TITLE
Handle loading indicator and empty state on user management page

### DIFF
--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -23,7 +23,7 @@ const UserManagement = () => {
   const { toast } = useToast();
   
   const {
-    users,
+    users: filteredUsers,
     pagination,
     goToPage,
     setPageSize,
@@ -145,8 +145,14 @@ const UserManagement = () => {
               </CardContent>
             </Card>
           ))
+        ) : !loading && filteredUsers.length === 0 ? (
+          <Card>
+            <CardContent className="p-12 text-center text-muted-foreground">
+              표시할 사용자가 없습니다.
+            </CardContent>
+          </Card>
         ) : (
-          users.map((user) => {
+          filteredUsers.map((user) => {
             const instructor = getUserInstructor(user.id);
             const roles = userRoles[user.id] || [];
 


### PR DESCRIPTION
## Summary
- render skeleton cards when the user list is loading
- gate the empty-state message behind the loading flag and filtered user length
- alias the paginated users array to `filteredUsers` for clarity when rendering

## Testing
- `npm run lint` *(fails: missing @eslint/js due to npm registry tailwindcss 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd6157a48c8324bb1a8fabdc767e38