### PR TITLE
feat: use aggregated course report statistics

### DIFF
--- a/src/components/course-reports/CourseSelector.tsx
+++ b/src/components/course-reports/CourseSelector.tsx
@@ -2,20 +2,22 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Target } from 'lucide-react';
+import { CourseOption } from '@/repositories/courseReportsRepository';
 
 interface CourseSelectorProps {
   selectedYear: number;
   selectedCourse: string;
-  selectedRound: number | null;                 // null = 전체
-  selectedInstructor: string;                   // ''   = 전체
-  availableCourses: {year: number, round: number, course_name: string, key: string, rounds?: number[]}[];
+  selectedRound: number | null;
+  selectedInstructor: string;
+  availableCourses: CourseOption[];
   availableRounds: number[];
-  availableInstructors: {id: string, name: string}[];
+  availableInstructors: { id: string; name: string }[];
   years: number[];
   onYearChange: (year: string) => void;
   onCourseChange: (course: string) => void;
-  onRoundChange: (round: string) => void;       // ''   = 전체  (부모 호환 유지)
-  onInstructorChange: (instructor: string) => void; // ''= 전체
+  onRoundChange: (round: string) => void;
+  onInstructorChange: (instructor: string) => void;
+  testDataToggle?: React.ReactNode;
 }
 
 const CourseSelector: React.FC<CourseSelectorProps> = ({
@@ -30,23 +32,23 @@ const CourseSelector: React.FC<CourseSelectorProps> = ({
   onYearChange,
   onCourseChange,
   onRoundChange,
-  onInstructorChange
+  onInstructorChange,
+  testDataToggle,
 }) => {
-  // 렌더링용 값 보정: 전체일 때는 'all' 토큰 사용 (빈 문자열 금지 규칙 회피)
   const roundValue = selectedRound === null ? 'all' : String(selectedRound);
   const instructorValue = selectedInstructor && selectedInstructor.trim() !== '' ? selectedInstructor : 'all';
 
   return (
     <Card className="shadow-lg border-0 bg-gradient-to-r from-card to-card/50">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
+      <CardHeader className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
           <Target className="h-5 w-5 text-primary" />
-          과정별 결과 필터
-        </CardTitle>
+          <CardTitle>과정별 결과 필터</CardTitle>
+        </div>
+        {testDataToggle}
       </CardHeader>
 
       <CardContent className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        {/* 교육 연도 */}
         <div>
           <label className="text-sm font-medium">교육 연도</label>
           <Select value={selectedYear.toString()} onValueChange={onYearChange}>
@@ -63,7 +65,6 @@ const CourseSelector: React.FC<CourseSelectorProps> = ({
           </Select>
         </div>
 
-        {/* 과정명 */}
         <div>
           <label className="text-sm font-medium">과정</label>
           <Select value={selectedCourse} onValueChange={onCourseChange}>
@@ -72,15 +73,14 @@ const CourseSelector: React.FC<CourseSelectorProps> = ({
             </SelectTrigger>
             <SelectContent>
               {availableCourses.map((course) => (
-                <SelectItem key={course.key} value={course.key}>
-                  {course.course_name}
+                <SelectItem key={course.normalizedName} value={course.normalizedName}>
+                  {course.displayName || course.normalizedName}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
 
-        {/* 교육 차수 */}
         <div>
           <label className="text-sm font-medium">교육 차수</label>
           <Select
@@ -89,7 +89,7 @@ const CourseSelector: React.FC<CourseSelectorProps> = ({
             disabled={!selectedCourse}
           >
             <SelectTrigger>
-              <SelectValue placeholder={selectedCourse ? "차수 선택" : "먼저 과정을 선택하세요"} />
+              <SelectValue placeholder={selectedCourse ? '차수 선택' : '먼저 과정을 선택하세요'} />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">전체</SelectItem>
@@ -102,22 +102,21 @@ const CourseSelector: React.FC<CourseSelectorProps> = ({
           </Select>
         </div>
 
-        {/* 담당 강사 */}
         <div>
           <label className="text-sm font-medium">강사</label>
           <Select
             value={instructorValue}
-            onValueChange={(v) => onInstructorChange(v === 'all' ? '' : v)} // 'all' 선택 시 ''로 역변환
+            onValueChange={(v) => onInstructorChange(v === 'all' ? '' : v)}
           >
             <SelectTrigger>
               <SelectValue placeholder="강사 선택" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">전체</SelectItem> {/* 빈 문자열 대신 */}
+              <SelectItem value="all">전체</SelectItem>
               {availableInstructors
-                .filter((i) => i?.id && String(i.id).trim() !== '')
+                .filter((instructor) => instructor?.id && instructor.id.trim() !== '')
                 .map((instructor) => (
-                  <SelectItem key={String(instructor.id)} value={String(instructor.id)}>
+                  <SelectItem key={instructor.id} value={instructor.id}>
                     {instructor.name}
                   </SelectItem>
                 ))}

--- a/src/hooks/useCourseReportStatistics.ts
+++ b/src/hooks/useCourseReportStatistics.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+import {
+  CourseReportFilters,
+  CourseReportStatisticsResponse,
+  CourseReportsRepository,
+} from '@/repositories/courseReportsRepository';
+
+interface UseCourseReportStatisticsResult {
+  data: CourseReportStatisticsResponse | null;
+  loading: boolean;
+  error: string | null;
+  fetchStatistics: (filters: CourseReportFilters) => Promise<CourseReportStatisticsResponse | null>;
+}
+
+export function useCourseReportStatistics(): UseCourseReportStatisticsResult {
+  const [data, setData] = useState<CourseReportStatisticsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatistics = useCallback(async (filters: CourseReportFilters) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await CourseReportsRepository.fetchStatistics(filters);
+      setData(result);
+      return result;
+    } catch (err) {
+      console.error('Failed to fetch course report statistics', err);
+      setError('데이터를 불러오는 중 오류가 발생했습니다.');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { data, loading, error, fetchStatistics };
+}

--- a/src/hooks/useCourseReportsData.tsx
+++ b/src/hooks/useCourseReportsData.tsx
@@ -1,1064 +1,170 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
+import {
+  CourseOption,
+  CourseReportStatisticsResponse,
+  CourseReportsRepository,
+} from '@/repositories/courseReportsRepository';
+import { useCourseReportStatistics } from '@/hooks/useCourseReportStatistics';
 
-interface CourseStatistics {
-  id: string;
-  year: number;
-  round: number;
-  course_days: number;
-  course_start_date: string;
-  course_end_date: string;
-  status: string;
-  enrolled_count: number;
-  cumulative_count: number;
-  total_satisfaction: number | null;
-  course_satisfaction: number | null;
-  instructor_satisfaction: number | null;
-  operation_satisfaction: number | null;
-  education_hours: number | null;
-  education_days: number | null;
-  course_name: string | null;
+export interface UseCourseReportsDataResult {
+  summary: CourseReportStatisticsResponse['summary'] | null;
+  previousSummary: CourseReportStatisticsResponse['summary'] | null;
+  trend: CourseReportStatisticsResponse['trend'];
+  instructorStats: CourseReportStatisticsResponse['instructorStats'];
+  previousInstructorStats: CourseReportStatisticsResponse['instructorStats'];
+  textualResponses: CourseReportStatisticsResponse['textualResponses'];
+  availableCourses: CourseOption[];
+  availableRounds: number[];
+  availableInstructors: { id: string; name: string }[];
+  loading: boolean;
+  isInstructor: boolean;
+  instructorId: string | null;
+  refetch: () => Promise<CourseReportStatisticsResponse | null>;
 }
-
-interface CourseReport {
-  id: string;
-  education_year: number;
-  education_round: number;
-  course_title: string;
-  total_surveys: number;
-  total_responses: number;
-  avg_instructor_satisfaction: number;
-  avg_course_satisfaction: number;
-  report_data: any;
-  created_at: string;
-}
-
-interface InstructorStats {
-  instructor_id: string;
-  instructor_name: string;
-  survey_count: number;
-  response_count: number;
-  avg_satisfaction: number;
-}
-
-interface AvailableCourse {
-  year: number;
-  round: number;
-  course_name: string;
-  key: string;
-  rounds: number[];
-}
-
-// 코스명 정규화: '홀수조/짝수조', '숫자조/숫자반' 등 분반 표기를 제거
-const normalizeCourseName = (name?: string | null) => {
-  if (!name) return '';
-  let n = String(name);
-  // 괄호 안의 '홀수조'/'짝수조' 제거
-  n = n.replace(/\((?:홀수조|짝수조)\)/g, '');
-  // '11/12조' 같은 표기 제거
-  n = n.replace(/\b\d{1,2}\/\d{1,2}조\b/g, '');
-  // 차수 뒤에 위치한 '숫자조', '홀수조', '짝수조' 제거 (새로운 형식)
-  n = n.replace(/(\d+차-\d+일차)\s+\d{1,2}조/g, '$1');
-  n = n.replace(/(\d+차-\d+일차)\s+(?:홀수조|짝수조)/g, '$1');
-  // 끝이나 공백 앞의 '숫자조' 또는 '숫자반' 제거 (기존 형식)
-  n = n.replace(/\b\d{1,2}\s*(?:조|반)\b/g, '');
-  // '홀수조-', '짝수조-' 같은 형식 제거
-  n = n.replace(/(?:홀수조|짝수조)-/g, '');
-  // 여분 공백과 하이픈 정리
-  n = n.replace(/\s{2,}/g, ' ').replace(/-{2,}/g, '-').trim();
-  return n;
-};
-
-// 점수 파싱 유틸: answer_value 또는 answer_text에서 숫자 추출
-const parseScore = (val: any): number | null => {
-  if (val === null || val === undefined) return null;
-  if (typeof val === 'number') return val;
-  if (typeof val === 'string') {
-    const cleaned = val.replace(/"/g, '').trim();
-    const n = Number(cleaned);
-    return isNaN(n) ? null : n;
-  }
-  // JSON 문자열 같은 경우 처리
-  try {
-    const parsed = JSON.parse(val);
-    return typeof parsed === 'number' && isFinite(parsed) ? parsed : null;
-  } catch (_) {
-    return null;
-  }
-};
 
 export const useCourseReportsData = (
-  selectedYear: number, 
-  selectedCourse: string, 
-  selectedRound: number | null, 
-  selectedInstructor: string
-) => {
+  selectedYear: number,
+  selectedCourse: string,
+  selectedRound: number | null,
+  selectedInstructor: string,
+  includeTestData = false
+): UseCourseReportsDataResult => {
+  const { toast } = useToast();
   const { user, userRoles } = useAuth();
   const isInstructor = userRoles.includes('instructor');
-  const [instructorId, setInstructorId] = useState<string | null>(null);
-  
-  const [reports, setReports] = useState<CourseReport[]>([]);
-  const [previousReports, setPreviousReports] = useState<CourseReport[]>([]);
-  const [previousInstructorStats, setPreviousInstructorStats] = useState<InstructorStats[]>([]);
-  const [trendData, setTrendData] = useState<any[]>([]);
-  const [instructorStats, setInstructorStats] = useState<InstructorStats[]>([]);
-  const [availableCourses, setAvailableCourses] = useState<AvailableCourse[]>([]);
-  const [availableRounds, setAvailableRounds] = useState<number[]>([]);
-  const [availableInstructors, setAvailableInstructors] = useState<{id: string, name: string}[]>([]);
-  const [textualResponses, setTextualResponses] = useState<string[]>([]);
-  const [courseStatistics, setCourseStatistics] = useState<CourseStatistics[]>([]);
-  const [yearlyComparison, setYearlyComparison] = useState<{
-    current: CourseStatistics[];
-    previous: CourseStatistics[];
-  }>({ current: [], previous: [] });
-  const [loading, setLoading] = useState(true);
-  const { toast } = useToast();
 
-  // 강사 ID 찾기
+  const [instructorId, setInstructorId] = useState<string | null>(null);
+  const { data, loading, fetchStatistics } = useCourseReportStatistics();
+  const [previousData, setPreviousData] = useState<CourseReportStatisticsResponse | null>(null);
+
+  // Load instructor id for instructor role
   useEffect(() => {
     const fetchInstructorId = async () => {
-      if (isInstructor && user?.email) {
-        try {
-          const { data } = await supabase
-            .from('instructors')
-            .select('id')
-            .eq('email', user.email)
-            .maybeSingle();
-          
-          if (data) {
-            setInstructorId(data.id);
-          }
-        } catch (error) {
-          console.error('강사 ID 조회 오류:', error);
-        }
+      if (!isInstructor || !user?.email) {
+        setInstructorId(null);
+        return;
       }
+
+      const { data: instructor, error } = await supabase
+        .from('instructors')
+        .select('id')
+        .eq('email', user.email)
+        .maybeSingle();
+
+      if (error) {
+        console.error('Failed to fetch instructor id', error);
+        toast({
+          title: '오류',
+          description: '강사 정보를 불러오는 중 오류가 발생했습니다.',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      setInstructorId(instructor?.id ?? null);
     };
-    
+
     fetchInstructorId();
-  }, [isInstructor, user?.email]);
+  }, [isInstructor, user?.email, toast]);
 
-  const fetchAvailableCourses = async () => {
+  const instructorFilter = isInstructor ? instructorId : (selectedInstructor || null);
+
+  const refetch = useCallback(async () => {
+    if (!selectedYear) return null;
+    if (isInstructor && !instructorId) return null; // wait until instructor id is known
+
     try {
-      console.log('Fetching courses for year:', selectedYear);
-      
-      let query = supabase
-        .from('surveys')
-        .select('education_year, education_round, course_name')
-        .eq('education_year', selectedYear)
-        .in('status', ['completed', 'active'])
-        .not('course_name', 'is', null);
-
-      // 강사인 경우 본인 설문만 필터링
-      if (isInstructor && instructorId) {
-        query = query.eq('instructor_id', instructorId);
-      }
-
-      const { data: surveys, error } = await query;
-
-      if (error) throw error;
-
-      console.log('Fetched surveys for course selection:', surveys);
-
-      // 중복 제거 및 과정별 그룹화
-      // 코스명 정규화 기준으로 중복 제거 (분반/조 표기 제거 후 그룹화)
-      const courseGroups = new Map<string, any[]>();
-      (surveys || []).forEach((s: any) => {
-        const key = normalizeCourseName(s.course_name);
-        if (!courseGroups.has(key)) courseGroups.set(key, []);
-        courseGroups.get(key)!.push(s);
+      const current = await fetchStatistics({
+        year: selectedYear,
+        courseName: selectedCourse || null,
+        round: selectedRound ?? null,
+        instructorId: instructorFilter,
+        includeTestData,
       });
 
-      const uniqueCourses = Array.from(courseGroups.entries()).map(([key, group]) => {
-        const representative = group[0];
-        const courseRounds = Array.from(new Set(group.map((s: any) => s.education_round))).sort((a, b) => a - b);
-        return {
-          year: representative.education_year,
-          round: representative.education_round,
-          course_name: key,
-          key,
-          rounds: courseRounds,
-        };
-      });
-
-      // 사용 가능한 차수는 선택된 과정(또는 첫 과정)에 맞춰 설정
-      const normalizedSelectedCourse = normalizeCourseName(selectedCourse);
-      const matchedCourse = uniqueCourses.find(course => course.key === normalizedSelectedCourse);
-      const roundsToSet = matchedCourse
-        ? matchedCourse.rounds
-        : uniqueCourses.length > 0
-          ? uniqueCourses[0].rounds
-          : [];
-
-      setAvailableRounds([...roundsToSet]);
-
-      setAvailableCourses(uniqueCourses);
-      console.log('Available courses:', uniqueCourses);
-      console.log('Available rounds:', roundsToSet);
-
-      // 강사 정보 - 관리자만 가져오기 (모든 강사)
-      if (!isInstructor) {
-        const { data: instructors, error: instructorError } = await supabase
-          .from('instructors')
-          .select('id, name')
-          .order('name');
-
-        if (!instructorError && instructors) {
-          setAvailableInstructors(instructors);
+      if (current) {
+        try {
+          const previous = await CourseReportsRepository.fetchStatistics({
+            year: selectedYear - 1,
+            courseName: current.summary.normalizedCourseName ?? (selectedCourse || null),
+            round: selectedRound ?? null,
+            instructorId: instructorFilter,
+            includeTestData,
+          });
+          setPreviousData(previous);
+        } catch (prevError) {
+          console.error('Failed to fetch previous year statistics', prevError);
+          setPreviousData(null);
         }
       } else {
-        setAvailableInstructors([]); // 강사는 강사 필터 숨김
+        setPreviousData(null);
       }
-      
+
+      return current;
     } catch (error) {
-      console.error('Error fetching courses:', error);
+      console.error('Failed to load course report statistics', error);
       toast({
-        title: "오류",
-        description: "과정 목록을 불러오는 중 오류가 발생했습니다.",
-        variant: "destructive"
+        title: '오류',
+        description: '과정 보고서를 불러오는 중 오류가 발생했습니다.',
+        variant: 'destructive',
       });
+      return null;
     }
-  };
-
-  const fetchReports = async () => {
-    setLoading(true);
-    try {
-      console.log('Fetching reports for filters:', selectedYear, selectedCourse, selectedRound, selectedInstructor);
-      
-      // 설문조사 쿼리 구성
-      let query = supabase
-        .from('surveys')
-        .select(`
-          id,
-          education_year,
-          education_round,
-          course_name,
-          title,
-          course_id,
-          instructor_id,
-          courses (title),
-          instructors (id, name),
-          survey_instructors (
-            instructor_id,
-            instructors (id, name)
-          ),
-          survey_sessions!survey_sessions_survey_id_fkey (
-            id,
-            instructor_id
-          ),
-          survey_responses (
-            id,
-          question_answers (
-            id,
-            answer_value,
-            answer_text,
-            survey_questions (satisfaction_type, question_type, session_id)
-          )
-          )
-        `)
-        .eq('education_year', selectedYear)
-        .in('status', ['completed', 'active']);
-
-      // 다중 강사 정보를 가져오는 함수
-      const getInstructorNames = (survey: any) => {
-        // 1. survey_instructors 테이블 확인
-        if (survey.survey_instructors && survey.survey_instructors.length > 0) {
-          const names = survey.survey_instructors
-            .map((si: any) => si.instructors?.name)
-            .filter(Boolean);
-          if (names.length > 0) return names.join(', ');
-        }
-        
-        // 2. 개별 instructor_id 확인
-        if (survey.instructors?.name) {
-          return survey.instructors.name;
-        }
-        
-        // 3. 과정명 사용
-        return survey.course_name || '강사 정보 없음';
-      };
-
-      // 강사인 경우 본인 설문만 필터링
-      if (isInstructor && instructorId) {
-        query = query.eq('instructor_id', instructorId);
-      }
-
-      // 필터 적용 (과정명은 정규화 비교 위해 서버 필터 제외하고 클라이언트에서 필터)
-      if (selectedRound) {
-        query = query.eq('education_round', selectedRound);
-      }
-      // 강사 필터는 조인 경로별 or 조건이 불안정하여 클라이언트에서 처리
-      // (instructor_id, survey_instructors, survey_sessions 모두 고려)
-
-      const { data: surveys, error: surveysError } = await query;
-
-      if (surveysError) throw surveysError;
-
-      console.log('Fetched detailed surveys:', surveys);
-      console.log('Selected instructor:', selectedInstructor);
-      console.log('Selected course (normalized):', selectedCourse);
-      console.log('Selected round:', selectedRound);
-      console.log('Total surveys before filtering:', surveys?.length || 0);
-
-      // 정규화된 과정명으로 클라이언트 측 필터링 (분반/조 통합)
-      const filteredSurveys = (surveys || []).filter((s: any) => {
-        // 과정명 필터
-        if (selectedCourse && normalizeCourseName(s.course_name) !== normalizeCourseName(selectedCourse)) {
-          return false;
-        }
-        
-        // 강사 필터 (클라이언트에서 안전하게 처리)
-        if (selectedInstructor) {
-          const hasMainInstructor = s.instructor_id === selectedInstructor;
-          const hasMultiInstructor = s.survey_instructors?.some((si: any) => si.instructor_id === selectedInstructor);
-          const hasSessionInstructor = s.survey_sessions?.some((ss: any) => ss.instructor_id === selectedInstructor);
-          
-          if (!hasMainInstructor && !hasMultiInstructor && !hasSessionInstructor) {
-            return false;
-          }
-        }
-        
-        return true;
-      });
-
-      console.log('Surveys after all filtering:', filteredSurveys.length);
-      // 데이터 집계
-      const instructorStatsMap = new Map<string, any>();
-      let totalSurveys = 0;
-      let totalResponses = 0;
-      let allInstructorSatisfactions: number[] = [];
-      let allCourseSatisfactions: number[] = [];
-      let allOperationSatisfactions: number[] = [];
-
-      filteredSurveys.forEach(survey => {
-        console.log('Processing survey:', survey.id, 'instructor_id:', survey.instructor_id, 'responses:', survey.survey_responses?.length);
-
-        totalSurveys += 1;
-        totalResponses += survey.survey_responses?.length || 0;
-
-        // 강사 정보 처리 개선 - 설문 내 모든 강사 식별
-        const surveyInstructorIds = new Set<string>();
-        const instructorNameMap = new Map<string, string>();
-        const sessionInstructorMap = new Map<string, string>();
-
-        const mainInstructorName = (() => {
-          if ((survey as any).survey_instructors && (survey as any).survey_instructors.length > 0) {
-            const names = (survey as any).survey_instructors
-              .map((si: any) => si.instructors?.name)
-              .filter(Boolean);
-            if (names.length > 0) return names.join(', ');
-          }
-          if ((survey as any).instructors?.name) return (survey as any).instructors.name;
-          return (survey as any).course_name || '강사 정보 없음';
-        })();
-
-        const ensureInstructorEntry = (id?: string | null, name?: string | null) => {
-          if (!id) return;
-          const existingName = instructorNameMap.get(id);
-          const fallbackName = survey.instructor_id === id ? mainInstructorName : undefined;
-          const resolvedName = name ?? existingName ?? fallbackName ?? '강사 정보 없음';
-
-          if (!existingName || existingName === '강사 정보 없음') {
-            instructorNameMap.set(id, resolvedName);
-          }
-
-          if (!instructorStatsMap.has(id)) {
-            instructorStatsMap.set(id, {
-              instructor_id: id,
-              instructor_name: resolvedName,
-              survey_count: 0,
-              response_count: 0,
-              satisfactions: [] as number[],
-            });
-          } else {
-            const stat = instructorStatsMap.get(id);
-            if ((!stat.instructor_name || stat.instructor_name === '강사 정보 없음') && resolvedName) {
-              stat.instructor_name = resolvedName;
-            }
-          }
-
-          surveyInstructorIds.add(id);
-        };
-
-        if (survey.instructors?.id) {
-          if (survey.instructors.name) {
-            instructorNameMap.set(survey.instructors.id, survey.instructors.name);
-          }
-        }
-
-        if (survey.survey_instructors && Array.isArray(survey.survey_instructors)) {
-          survey.survey_instructors.forEach((si: any) => {
-            const relatedId = si.instructor_id ?? si.instructors?.id;
-            const relatedName = si.instructors?.name ?? null;
-            if (relatedId && relatedName) {
-              instructorNameMap.set(relatedId, relatedName);
-            }
-            ensureInstructorEntry(relatedId, relatedName);
-          });
-        }
-
-        ensureInstructorEntry(survey.instructor_id, mainInstructorName);
-
-        if (survey.survey_sessions && Array.isArray(survey.survey_sessions)) {
-          survey.survey_sessions.forEach((session: any) => {
-            if (!session?.id || !session?.instructor_id) return;
-            sessionInstructorMap.set(session.id, session.instructor_id);
-
-            const sessionInstructorName = instructorNameMap.get(session.instructor_id)
-              ?? survey.survey_instructors?.find((si: any) => (si.instructor_id ?? si.instructors?.id) === session.instructor_id)?.instructors?.name
-              ?? (survey.instructors?.id === session.instructor_id ? survey.instructors?.name : undefined)
-              ?? null;
-
-            ensureInstructorEntry(session.instructor_id, sessionInstructorName);
-          });
-        }
-
-        surveyInstructorIds.forEach(id => {
-          const stat = instructorStatsMap.get(id);
-          if (stat) {
-            stat.survey_count += 1;
-          }
-        });
-
-        survey.survey_responses?.forEach((response: any) => {
-          response.question_answers?.forEach((answer: any) => {
-            if (answer.survey_questions?.question_type === 'scale' && (answer.answer_value != null || answer.answer_text != null)) {
-              let scoreRaw = parseScore((answer as any).answer_value ?? (answer as any).answer_text);
-              if (scoreRaw === null) return;
-              let score = scoreRaw;
-
-              // 유효성 검사 - NaN과 무효한 값 필터링
-              if (isNaN(score) || score <= 0 || !isFinite(score)) {
-                return;
-              }
-
-              // 5점 척도를 10점으로 변환 (10점 척도는 그대로 유지)
-              if (score <= 5 && score > 0) {
-                score = score * 2;
-              }
-
-              if (answer.survey_questions.satisfaction_type === 'instructor') {
-                const targetInstructorIds: string[] = [];
-
-                const sessionId = answer.survey_questions?.session_id as string | undefined;
-                if (sessionId) {
-                  const sessionInstructorId = sessionInstructorMap.get(sessionId);
-                  if (sessionInstructorId) {
-                    targetInstructorIds.push(sessionInstructorId);
-                  }
-                }
-
-                const uniqueTargetInstructorIds = Array.from(new Set(targetInstructorIds.filter(Boolean)));
-
-                if (selectedInstructor) {
-                  if (uniqueTargetInstructorIds.length === 0) {
-                    if (surveyInstructorIds.has(selectedInstructor)) {
-                      uniqueTargetInstructorIds.push(selectedInstructor);
-                    } else {
-                      return;
-                    }
-                  } else if (!uniqueTargetInstructorIds.includes(selectedInstructor)) {
-                    return;
-                  }
-                } else if (uniqueTargetInstructorIds.length === 0 && surveyInstructorIds.size === 1) {
-                  const [onlyInstructorId] = Array.from(surveyInstructorIds);
-                  if (onlyInstructorId) {
-                    uniqueTargetInstructorIds.push(onlyInstructorId);
-                  }
-                }
-
-                allInstructorSatisfactions.push(score);
-
-                uniqueTargetInstructorIds.forEach((id) => {
-                  const stat = instructorStatsMap.get(id);
-                  if (stat) {
-                    stat.satisfactions.push(score);
-                    stat.response_count += 1;
-                    if ((!stat.instructor_name || stat.instructor_name === '강사 정보 없음') && instructorNameMap.get(id)) {
-                      stat.instructor_name = instructorNameMap.get(id);
-                    }
-                  }
-                });
-              } else if (answer.survey_questions.satisfaction_type === 'course') {
-                allCourseSatisfactions.push(score);
-              } else if (answer.survey_questions.satisfaction_type === 'operation') {
-                allOperationSatisfactions.push(score);
-              }
-            }
-          });
-        });
-      });
-
-      const finalInstructorStats = Array.from(instructorStatsMap.values()).map(stat => {
-        const validSatisfactions = stat.satisfactions.filter(s => !isNaN(s) && isFinite(s));
-        const avgSatisfaction = validSatisfactions.length > 0
-          ? validSatisfactions.reduce((a: number, b: number) => a + b, 0) / validSatisfactions.length
-          : 0;
-        
-        return {
-          ...stat,
-          avg_satisfaction: isNaN(avgSatisfaction) || !isFinite(avgSatisfaction) ? 0 : Number(avgSatisfaction.toFixed(1))
-        };
-      }).filter(stat => stat.survey_count > 0); // 실제 데이터가 있는 강사만 포함
-
-      // 유효한 만족도 점수만 필터링
-      const validInstructorSatisfactions = allInstructorSatisfactions.filter(s => !isNaN(s) && isFinite(s));
-      const validCourseSatisfactions = allCourseSatisfactions.filter(s => !isNaN(s) && isFinite(s));
-      const validOperationSatisfactions = allOperationSatisfactions.filter(s => !isNaN(s) && isFinite(s));
-
-      // 평균 계산 함수
-      const calculateAverage = (scores: number[]) => {
-        if (scores.length === 0) return 0;
-        const avg = scores.reduce((a, b) => a + b, 0) / scores.length;
-        return isNaN(avg) || !isFinite(avg) ? 0 : Number(avg.toFixed(1));
-      };
-
-      // 종합 통계 생성
-      const courseReport: CourseReport = {
-        id: `${selectedYear}-${selectedCourse || 'all'}-${selectedRound || 'all'}-${selectedInstructor || 'all'}`,
-        education_year: selectedYear,
-        education_round: selectedRound || 0,
-        course_title: selectedCourse || (isInstructor ? '내 담당 과정' : '전체 과정'),
-        total_surveys: totalSurveys,
-        total_responses: totalResponses,
-        avg_instructor_satisfaction: calculateAverage(validInstructorSatisfactions),
-        avg_course_satisfaction: calculateAverage(validCourseSatisfactions),
-        report_data: {
-          operation_satisfaction: calculateAverage(validOperationSatisfactions),
-          instructor_count: finalInstructorStats.length,
-          satisfaction_distribution: {
-            instructor: validInstructorSatisfactions,
-            course: validCourseSatisfactions,
-            operation: validOperationSatisfactions
-          }
-        },
-        created_at: new Date().toISOString()
-      };
-
-      console.log('Generated course report:', courseReport);
-      console.log('Instructor stats:', finalInstructorStats);
-      console.log('Generated course report:', courseReport);
-      console.log('Final instructor stats:', finalInstructorStats);
-      setReports([courseReport]);
-      setInstructorStats(finalInstructorStats);
-
-      // 이전 차수 데이터 가져오기
-      await fetchPreviousReports(selectedYear, selectedCourse, selectedRound);
-      
-      // 트렌드 데이터 가져오기 (최근 5개 차수)
-      await fetchTrendData(selectedYear, selectedCourse);
-
-      // 서술형 응답 가져오기
-      await fetchTextualResponses(filteredSurveys);
-
-      // 과정별 통계 가져오기
-      await fetchCourseStatistics(selectedYear);
-
-      // 전년도 대비 통계 가져오기
-      await fetchYearlyComparison(selectedYear, selectedYear - 1);
-
-    } catch (error) {
-      console.error('Error fetching reports:', error);
-      toast({
-        title: "오류",
-        description: "결과 보고서를 불러오는 중 오류가 발생했습니다.",
-        variant: "destructive"
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const fetchPreviousReports = async (year: number, course: string, round: number | null) => {
-    try {
-      const previousRound = round ? round - 1 : null;
-      if (!previousRound || previousRound < 1) return;
-
-      let query = supabase
-        .from('surveys')
-        .select(`
-          id,
-          education_year,
-          education_round,
-          course_name,
-          instructor_id,
-          instructors (
-            id,
-            name
-          ),
-          survey_responses (
-            id,
-          question_answers (
-            id,
-            answer_value,
-            answer_text,
-            survey_questions (satisfaction_type, question_type)
-          )
-          )
-        `)
-        .eq('education_year', year)
-        .eq('education_round', previousRound)
-        .in('status', ['completed', 'active']);
-
-      // 강사 필터링 적용
-      if (isInstructor && instructorId) {
-        query = query.eq('instructor_id', instructorId);
-      }
-
-      if (course) {
-        query = query.eq('course_name', course);
-      }
-
-      const { data: prevSurveys } = await query;
-      
-      if (prevSurveys) {
-        // 이전 차수 통계 계산 (현재 로직과 동일)
-        let prevInstructorSatisfactions: number[] = [];
-        let prevCourseSatisfactions: number[] = [];
-        let prevOperationSatisfactions: number[] = [];
-        let prevTotalResponses = 0;
-
-        prevSurveys.forEach(survey => {
-          prevTotalResponses += survey.survey_responses?.length || 0;
-          
-          survey.survey_responses?.forEach(response => {
-            response.question_answers?.forEach(answer => {
-            if (answer.survey_questions?.question_type === 'scale' && (answer.answer_value != null || answer.answer_text != null)) {
-              let scoreRaw = parseScore((answer as any).answer_value ?? (answer as any).answer_text);
-              if (scoreRaw === null) return;
-              let score = scoreRaw;
-              if (score <= 5 && score > 0) score = score * 2;
-              
-              if (answer.survey_questions.satisfaction_type === 'instructor') {
-                prevInstructorSatisfactions.push(score);
-              } else if (answer.survey_questions.satisfaction_type === 'course') {
-                prevCourseSatisfactions.push(score);
-              } else if (answer.survey_questions.satisfaction_type === 'operation') {
-                prevOperationSatisfactions.push(score);
-              }
-            }
-            });
-          });
-        });
-
-        const prevReport: CourseReport = {
-          id: `prev-${year}-${course || 'all'}-${previousRound}`,
-          education_year: year,
-          education_round: previousRound,
-          course_title: course || (isInstructor ? '내 담당 과정' : '전체 과정'),
-          total_surveys: prevSurveys.length,
-          total_responses: prevTotalResponses,
-          avg_instructor_satisfaction: prevInstructorSatisfactions.length > 0 
-            ? prevInstructorSatisfactions.reduce((a, b) => a + b, 0) / prevInstructorSatisfactions.length 
-            : 0,
-          avg_course_satisfaction: prevCourseSatisfactions.length > 0
-            ? prevCourseSatisfactions.reduce((a, b) => a + b, 0) / prevCourseSatisfactions.length
-            : 0,
-          report_data: {
-            operation_satisfaction: prevOperationSatisfactions.length > 0
-              ? prevOperationSatisfactions.reduce((a, b) => a + b, 0) / prevOperationSatisfactions.length
-              : 0
-          },
-          created_at: new Date().toISOString()
-        };
-
-        setPreviousReports([prevReport]);
-        
-        // 이전 차수 강사별 통계도 계산
-        const prevInstructorStatsMap = new Map<string, {
-          survey_count: number;
-          response_count: number;
-          instructor_satisfactions: number[];
-          instructor_name: string;
-        }>();
-
-        prevSurveys.forEach(survey => {
-          if (survey.instructor_id) {
-            const existingStat = prevInstructorStatsMap.get(survey.instructor_id) || {
-              survey_count: 0,
-              response_count: 0,
-              instructor_satisfactions: [],
-              instructor_name: (() => {
-                // survey_instructors 확인
-                if ((survey as any).survey_instructors && (survey as any).survey_instructors.length > 0) {
-                  const names = (survey as any).survey_instructors
-                    .map((si: any) => si.instructors?.name)
-                    .filter(Boolean);
-                  if (names.length > 0) return names.join(', ');
-                }
-                // 개별 instructor 확인
-                if ((survey as any).instructors?.name) return (survey as any).instructors.name;
-                // 과정명 사용
-                return (survey as any).course_name || '강사 정보 없음';
-              })()
-            };
-
-            existingStat.survey_count += 1;
-            existingStat.response_count += survey.survey_responses?.length || 0;
-
-            survey.survey_responses?.forEach(response => {
-              response.question_answers?.forEach(answer => {
-                if (answer.survey_questions?.satisfaction_type === 'instructor' && 
-                    answer.survey_questions?.question_type === 'scale' && 
-                    (answer.answer_value != null || answer.answer_text != null)) {
-                  let scoreRaw = parseScore((answer as any).answer_value ?? (answer as any).answer_text);
-                  if (scoreRaw === null) return;
-                  let score = scoreRaw;
-                  if (score <= 5 && score > 0) score = score * 2;
-                  existingStat.instructor_satisfactions.push(score);
-                }
-              });
-            });
-
-            prevInstructorStatsMap.set(survey.instructor_id, existingStat);
-          }
-        });
-
-        const prevInstructorStats: InstructorStats[] = Array.from(prevInstructorStatsMap.entries()).map(([id, stat]) => ({
-          instructor_id: id,
-          instructor_name: stat.instructor_name,
-          survey_count: stat.survey_count,
-          response_count: stat.response_count,
-          avg_satisfaction: stat.instructor_satisfactions.length > 0 
-            ? stat.instructor_satisfactions.reduce((a, b) => a + b, 0) / stat.instructor_satisfactions.length 
-            : 0
-        }));
-
-        setPreviousInstructorStats(prevInstructorStats);
-      }
-    } catch (error) {
-      console.error('Error fetching previous reports:', error);
-    }
-  };
-
-  const fetchTrendData = async (year: number, course: string) => {
-    try {
-      // 최근 5개 차수의 데이터 가져오기
-      let query = supabase
-        .from('surveys')
-        .select(`
-          education_year,
-          education_round,
-          course_name,
-          instructor_id,
-          survey_sessions (
-            id,
-            instructor_id
-          ),
-          survey_responses (
-            id,
-          question_answers (
-            answer_value,
-            answer_text,
-            survey_questions (satisfaction_type, question_type, session_id)
-          )
-          )
-        `)
-        .eq('education_year', year)
-        .in('status', ['completed', 'active'])
-        .order('education_round', { ascending: true });
-
-      // 강사 필터링 적용
-      if (isInstructor && instructorId) {
-        query = query.eq('instructor_id', instructorId);
-      }
-
-      // 과정명은 정규화 후 클라이언트에서 필터링
-
-      const { data: trendSurveys } = await query;
-      
-      const filteredTrendSurveys = (trendSurveys || []).filter((s: any) => {
-        if (course) return normalizeCourseName(s.course_name) === course;
-        return true;
-      });
-      
-      if (filteredTrendSurveys) {
-        const trendMap = new Map();
-        
-        filteredTrendSurveys.forEach((survey: any) => {
-          const round = survey.education_round;
-          if (!trendMap.has(round)) {
-            trendMap.set(round, {
-              round,
-              instructor: [],
-              course: [],
-              operation: []
-            });
-          }
-          
-          const roundData = trendMap.get(round);
-          
-          survey.survey_responses?.forEach((response: any) => {
-          response.question_answers?.forEach((answer: any) => {
-            if (answer.survey_questions?.question_type === 'scale' && (answer.answer_value != null || answer.answer_text != null)) {
-              let scoreRaw = parseScore((answer as any).answer_value ?? (answer as any).answer_text);
-              if (scoreRaw === null) return;
-              let score = scoreRaw;
-              
-              // NaN 및 무효한 값 검증
-              if (isNaN(score) || !isFinite(score) || score <= 0) {
-                return; // 유효하지 않은 값은 건너뛰기
-              }
-              
-              if (score <= 5 && score > 0) score = score * 2;
-              
-              if (answer.survey_questions.satisfaction_type === 'instructor') {
-                roundData.instructor.push(score);
-              } else if (answer.survey_questions.satisfaction_type === 'course') {
-                roundData.course.push(score);
-              } else if (answer.survey_questions.satisfaction_type === 'operation') {
-                roundData.operation.push(score);
-              }
-            }
-          });
-          });
-        });
-
-        const trendArray = Array.from(trendMap.values())
-          .map(data => {
-            // 안전한 평균 계산 함수
-            const safeAverage = (arr: number[]) => {
-              if (!arr || arr.length === 0) return 0;
-              const validScores = arr.filter(score => !isNaN(score) && isFinite(score));
-              if (validScores.length === 0) return 0;
-              const avg = validScores.reduce((a, b) => a + b, 0) / validScores.length;
-              return isNaN(avg) || !isFinite(avg) ? 0 : Number(avg.toFixed(1));
-            };
-
-            return {
-              round: `${data.round}차`,
-              강사만족도: safeAverage(data.instructor),
-              과정만족도: safeAverage(data.course),
-              운영만족도: safeAverage(data.operation)
-            };
-          })
-          .filter(item => item.강사만족도 > 0 || item.과정만족도 > 0 || item.운영만족도 > 0)
-          .slice(-5); // 최근 5개만
-
-        console.log('Trend data calculated:', trendArray);
-        setTrendData(trendArray);
-      }
-    } catch (error) {
-      console.error('Error fetching trend data:', error);
-    }
-  };
-
-  const fetchTextualResponses = async (surveys: any[]) => {
-    try {
-      const textResponses: string[] = [];
-      
-      surveys?.forEach(survey => {
-        survey.survey_responses?.forEach(response => {
-          response.question_answers?.forEach(answer => {
-            if (answer.survey_questions?.question_type === 'text' && answer.answer_value) {
-              const text = typeof answer.answer_value === 'string' ? answer.answer_value : String(answer.answer_value);
-              if (text.trim().length > 0) {
-                textResponses.push(text.trim());
-              }
-            }
-          });
-        });
-      });
-
-      setTextualResponses(textResponses);
-    } catch (error) {
-      console.error('Error fetching textual responses:', error);
-    }
-  };
-
-  const fetchCourseStatistics = async (
-    year: number,
-    options?: { updateState?: boolean }
-  ) => {
-    const { updateState = true } = options || {};
-    try {
-      // surveys 테이블에서 직접 과정별 통계 계산
-      let query = supabase
-        .from('surveys')
-        .select(`
-          id,
-          education_year,
-          education_round,
-          course_name,
-          instructor_id,
-          instructors (name),
-          survey_responses (
-            id,
-          question_answers (
-            answer_value,
-            answer_text,
-            survey_questions (satisfaction_type, question_type)
-          )
-          )
-        `)
-        .eq('education_year', year)
-        .in('status', ['completed', 'active'])
-        .order('education_round', { ascending: true });
-
-      // 강사 필터링 적용
-      if (isInstructor && instructorId) {
-        query = query.eq('instructor_id', instructorId);
-      }
-
-      const { data: surveys, error } = await query;
-
-      if (error) throw error;
-
-      // 과정별로 데이터 집계
-      const courseMap = new Map();
-
-      surveys?.forEach(survey => {
-        const courseKey = normalizeCourseName(survey.course_name);
-        if (!courseMap.has(courseKey)) {
-          courseMap.set(courseKey, {
-            course_name: courseKey,
-            year: survey.education_year,
-            round: survey.education_round,
-            enrolled_count: 0,
-            total_responses: 0,
-            instructor_satisfactions: [],
-            course_satisfactions: [],
-            operation_satisfactions: []
-          });
-        }
-
-        const courseData = courseMap.get(courseKey);
-        courseData.enrolled_count += 1;
-        courseData.total_responses += survey.survey_responses?.length || 0;
-
-        // 만족도 점수 계산
-        survey.survey_responses?.forEach(response => {
-          response.question_answers?.forEach(answer => {
-            if (answer.survey_questions?.question_type === 'scale' && answer.answer_value) {
-              let score: number;
-              
-              if (typeof answer.answer_value === 'number') {
-                score = answer.answer_value;
-              } else if (typeof answer.answer_value === 'string') {
-                score = Number(answer.answer_value);
-              } else {
-                return;
-              }
-
-              if (isNaN(score) || score <= 0 || !isFinite(score)) return;
-
-              // 5점 척도를 10점으로 변환
-              if (score <= 5 && score > 0) {
-                score = score * 2;
-              }
-              
-              if (answer.survey_questions.satisfaction_type === 'instructor') {
-                courseData.instructor_satisfactions.push(score);
-              } else if (answer.survey_questions.satisfaction_type === 'course') {
-                courseData.course_satisfactions.push(score);
-              } else if (answer.survey_questions.satisfaction_type === 'operation') {
-                courseData.operation_satisfactions.push(score);
-              }
-            }
-          });
-        });
-      });
-
-      // 안전한 평균 계산 함수
-      const safeAverage = (arr: number[]) => {
-        if (!arr || arr.length === 0) return 0;
-        const validScores = arr.filter(score => !isNaN(score) && isFinite(score));
-        if (validScores.length === 0) return 0;
-        const avg = validScores.reduce((a, b) => a + b, 0) / validScores.length;
-        return isNaN(avg) || !isFinite(avg) ? 0 : Number(avg.toFixed(1));
-      };
-
-      // 최종 통계 계산
-      const statistics = Array.from(courseMap.values()).map(course => {
-        const instructorAvg = safeAverage(course.instructor_satisfactions);
-        const courseAvg = safeAverage(course.course_satisfactions);
-        const operationAvg = safeAverage(course.operation_satisfactions);
-        
-        // 전체 만족도는 모든 항목이 있을 때만 계산
-        const totalSatisfaction = instructorAvg > 0 && courseAvg > 0 && operationAvg > 0
-          ? Number(((instructorAvg + courseAvg + operationAvg) / 3).toFixed(1))
-          : 0;
-
-        return {
-          id: `${course.course_name}-${course.year}`,
-          year: course.year,
-          round: course.round,
-          course_name: course.course_name,
-          enrolled_count: course.enrolled_count,
-          cumulative_count: course.total_responses,
-          instructor_satisfaction: instructorAvg || 0,
-          course_satisfaction: courseAvg || 0,
-          operation_satisfaction: operationAvg || 0,
-          total_satisfaction: totalSatisfaction,
-          course_days: 5, // 기본값
-          course_start_date: new Date().toISOString().split('T')[0],
-          course_end_date: new Date().toISOString().split('T')[0],
-          status: 'completed',
-          education_hours: null,
-          education_days: null
-        };
-      });
-
-      if (updateState) {
-        setCourseStatistics(statistics);
-      }
-      console.log('Course statistics calculated:', statistics);
-      return statistics;
-    } catch (error) {
-      console.error('Error fetching course statistics:', error);
-      return [];
-    }
-  };
-
-  const fetchYearlyComparison = async (currentYear: number, previousYear: number) => {
-    try {
-      const [currentStats, previousStats] = await Promise.all([
-        fetchCourseStatistics(currentYear, { updateState: false }),
-        fetchCourseStatistics(previousYear, { updateState: false })
-      ]);
-
-      setYearlyComparison({
-        current: currentStats,
-        previous: previousStats
-      });
-    } catch (error) {
-      console.error('Error fetching yearly comparison:', error);
-    }
-  };
+  }, [
+    fetchStatistics,
+    includeTestData,
+    instructorFilter,
+    instructorId,
+    isInstructor,
+    selectedCourse,
+    selectedRound,
+    selectedYear,
+    toast,
+  ]);
 
   useEffect(() => {
-    if (!availableCourses || availableCourses.length === 0) {
-      setAvailableRounds([]);
-      return;
+    if (!selectedYear) return;
+    if (isInstructor && !instructorId) return;
+    refetch();
+  }, [
+    refetch,
+    selectedYear,
+    selectedCourse,
+    selectedRound,
+    instructorFilter,
+    includeTestData,
+    isInstructor,
+    instructorId,
+  ]);
+
+  const availableCourses = data?.availableCourses ?? [];
+
+  const availableRounds = useMemo(() => {
+    if (!data) return [];
+    const normalized = selectedCourse || data.summary.normalizedCourseName || '';
+    const matched = availableCourses.find((course) => course.normalizedName === normalized);
+    if (matched) {
+      return matched.rounds;
     }
-
-    const normalizedSelectedCourse = normalizeCourseName(selectedCourse);
-    const matchedCourse = availableCourses.find(course => course.key === normalizedSelectedCourse);
-    const fallbackCourse = matchedCourse ?? availableCourses[0];
-    const nextRounds = fallbackCourse?.rounds ?? [];
-
-    setAvailableRounds([...nextRounds]);
-  }, [selectedCourse, availableCourses]);
+    return data.summary.availableRounds ?? [];
+  }, [availableCourses, data, selectedCourse]);
 
   return {
-    reports,
-    previousReports,
-    trendData,
-    instructorStats,
-    previousInstructorStats,
+    summary: data?.summary ?? null,
+    previousSummary: previousData?.summary ?? null,
+    trend: data?.trend ?? [],
+    instructorStats: data?.instructorStats ?? [],
+    previousInstructorStats: previousData?.instructorStats ?? [],
+    textualResponses: data?.textualResponses ?? [],
     availableCourses,
     availableRounds,
-    availableInstructors,
-    textualResponses,
-    courseStatistics,
-    yearlyComparison,
+    availableInstructors: data?.availableInstructors ?? [],
     loading,
-    fetchAvailableCourses,
-    fetchReports,
-    fetchCourseStatistics,
-    fetchYearlyComparison,
     isInstructor,
-    instructorId
+    instructorId,
+    refetch,
   };
 };

--- a/src/pages/CourseReports.tsx
+++ b/src/pages/CourseReports.tsx
@@ -1,36 +1,49 @@
-// src/pages/CourseReports.tsx
-import React, { useState, useEffect } from 'react';
-import { DashboardLayout } from '@/components/layouts';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   ResponsiveContainer,
   XAxis,
   YAxis,
   CartesianGrid,
   Tooltip,
-  Bar,
   Legend,
   BarChart as ReBarChart,
   LineChart as ReLineChart,
+  Bar,
   Line,
-  ComposedChart,
+  Cell,
 } from 'recharts';
-import { TrendingUp, BookOpen, Star, Target, Download, User, Crown, AlertCircle, BarChart3, Share2 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
-import { useCourseReportsData } from '@/hooks/useCourseReportsData';
+import { BarChart3, BookOpen, Download, Share2, Star, Target, TrendingUp, User, Crown, AlertCircle } from 'lucide-react';
+import { DashboardLayout } from '@/components/layouts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import CourseSelector from '@/components/course-reports/CourseSelector';
 import InstructorStatsSection from '@/components/course-reports/InstructorStatsSection';
-import { SatisfactionStatusBadge } from '@/components/course-reports/SatisfactionStatusBadge';
-import { DrillDownModal } from '@/components/course-reports/DrillDownModal';
 import { KeywordCloud } from '@/components/course-reports/KeywordCloud';
+import { DrillDownModal } from '@/components/course-reports/DrillDownModal';
 import { generateCourseReportPDF } from '@/utils/pdfExport';
-import { Button } from '@/components/ui/button';
+import { useCourseReportsData } from '@/hooks/useCourseReportsData';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
+import { TestDataToggle } from '@/components/TestDataToggle';
+import { useTestDataToggle } from '@/hooks/useTestDataToggle';
 
-const CourseReports = () => {
-  const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear());
+const CURRENT_YEAR = new Date().getFullYear();
+const YEARS = Array.from({ length: 5 }, (_, index) => CURRENT_YEAR - index);
+
+const toFixedOrZero = (value: number | null | undefined, digits = 1) => {
+  if (typeof value !== 'number' || !isFinite(value)) return 0;
+  const rounded = Number(value.toFixed(digits));
+  return isNaN(rounded) ? 0 : rounded;
+};
+
+const CourseReports: React.FC = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { userRoles } = useAuth();
+  const testDataOptions = useTestDataToggle();
+
+  const [selectedYear, setSelectedYear] = useState<number>(CURRENT_YEAR);
   const [selectedCourse, setSelectedCourse] = useState<string>('');
   const [selectedRound, setSelectedRound] = useState<number | null>(null);
   const [selectedInstructor, setSelectedInstructor] = useState<string>('');
@@ -39,59 +52,157 @@ const CourseReports = () => {
     type: 'instructor' | 'course' | 'operation';
     title: string;
   }>({ isOpen: false, type: 'instructor', title: '' });
-  
-  const navigate = useNavigate();
-  const { toast } = useToast();
-  const { userRoles } = useAuth();
-  
+
   const isInstructor = userRoles.includes('instructor');
   const isAdmin = userRoles.includes('admin');
 
   const {
-    reports,
-    previousReports,
-    trendData,
+    summary,
+    previousSummary,
+    trend,
     instructorStats,
+    previousInstructorStats,
+    textualResponses,
     availableCourses,
     availableRounds,
     availableInstructors,
-    textualResponses,
-    courseStatistics,
-    yearlyComparison,
     loading,
-    fetchAvailableCourses,
-    fetchReports,
-    fetchYearlyComparison,
     isInstructor: hookIsInstructor,
-    instructorId
-  } = useCourseReportsData(selectedYear, selectedCourse, selectedRound, selectedInstructor);
+    instructorId,
+  } = useCourseReportsData(
+    selectedYear,
+    selectedCourse,
+    selectedRound,
+    selectedInstructor,
+    testDataOptions.includeTestData
+  );
 
   useEffect(() => {
-    fetchAvailableCourses();
-  }, [selectedYear]);
-
-  useEffect(() => {
-    if (selectedCourse || selectedRound || selectedInstructor) {
-      fetchReports();
-    }
-  }, [selectedCourse, selectedRound, selectedInstructor, instructorId]);
-
-  useEffect(() => {
-    if (availableCourses.length > 0 && !selectedCourse) {
-      setSelectedCourse(availableCourses[0].key);
-    }
+    if (availableCourses.length === 0) return;
+    if (selectedCourse && availableCourses.some((course) => course.normalizedName === selectedCourse)) return;
+    setSelectedCourse(availableCourses[0].normalizedName);
   }, [availableCourses, selectedCourse]);
 
-  const handleInstructorClick = (instructorId: string) => {
-    navigate(`/dashboard/instructor-details/${instructorId}?year=${selectedYear}`);
+  useEffect(() => {
+    if (!selectedRound) return;
+    if (!availableRounds.includes(selectedRound)) {
+      setSelectedRound(null);
+    }
+  }, [availableRounds, selectedRound]);
+
+  useEffect(() => {
+    if (!selectedInstructor) return;
+    if (!availableInstructors.some((instructor) => instructor.id === selectedInstructor)) {
+      setSelectedInstructor('');
+    }
+  }, [availableInstructors, selectedInstructor]);
+
+  const currentCourseName = useMemo(() => {
+    if (summary?.courseName) return summary.courseName;
+    const fallback = availableCourses.find((course) => course.normalizedName === selectedCourse);
+    return fallback?.displayName ?? selectedCourse;
+  }, [summary?.courseName, availableCourses, selectedCourse]);
+
+  const satisfactionChartData = useMemo(() => {
+    if (!summary) return [];
+    return [
+      {
+        name: '강사 만족도',
+        value: toFixedOrZero(summary.avgInstructorSatisfaction),
+        fill: 'hsl(var(--chart-1))',
+      },
+      {
+        name: '과정 만족도',
+        value: toFixedOrZero(summary.avgCourseSatisfaction),
+        fill: 'hsl(var(--chart-2))',
+      },
+      {
+        name: '운영 만족도',
+        value: toFixedOrZero(summary.avgOperationSatisfaction),
+        fill: 'hsl(var(--chart-3))',
+      },
+    ];
+  }, [summary]);
+
+  const trendChartData = useMemo(() =>
+    trend
+      .map((point) => ({
+        name: point.educationRound ? `${point.educationRound}차` : '전체',
+        강사만족도: toFixedOrZero(point.avgInstructorSatisfaction),
+        과정만족도: toFixedOrZero(point.avgCourseSatisfaction),
+        운영만족도: toFixedOrZero(point.avgOperationSatisfaction),
+      }))
+      .filter((item) => item.강사만족도 > 0 || item.과정만족도 > 0 || item.운영만족도 > 0),
+    [trend]
+  );
+
+  const instructorStatsDisplay = useMemo(
+    () =>
+      instructorStats.map((stat) => ({
+        instructor_id: stat.instructorId ?? '',
+        instructor_name: stat.instructorName,
+        survey_count: stat.surveyCount,
+        response_count: stat.responseCount,
+        avg_satisfaction: toFixedOrZero(stat.avgSatisfaction),
+      })),
+    [instructorStats]
+  );
+
+  const previousInstructorStatsDisplay = useMemo(
+    () =>
+      previousInstructorStats.map((stat) => ({
+        instructor_id: stat.instructorId ?? '',
+        instructor_name: stat.instructorName,
+        survey_count: stat.surveyCount,
+        response_count: stat.responseCount,
+        avg_satisfaction: toFixedOrZero(stat.avgSatisfaction),
+      })),
+    [previousInstructorStats]
+  );
+
+  const overallSatisfaction = useMemo(() => {
+    if (!summary) return 0;
+    const scores = [
+      summary.avgInstructorSatisfaction,
+      summary.avgCourseSatisfaction,
+      summary.avgOperationSatisfaction,
+    ].map((value) => (typeof value === 'number' && isFinite(value) ? value : null));
+    const validScores = scores.filter((value): value is number => typeof value === 'number');
+    if (validScores.length === 0) return 0;
+    const average = validScores.reduce((acc, value) => acc + value, 0) / validScores.length;
+    return toFixedOrZero(average);
+  }, [summary]);
+
+  const calculateChange = (current?: number, previous?: number) => {
+    if (!current || !previous || previous === 0) return null;
+    const change = current - previous;
+    const percentage = (change / previous) * 100;
+    return { change, percentage };
+  };
+
+  const surveyChange = summary && previousSummary
+    ? calculateChange(summary.totalSurveys, previousSummary.totalSurveys)
+    : null;
+  const responseChange = summary && previousSummary
+    ? calculateChange(summary.totalResponses, previousSummary.totalResponses)
+    : null;
+  const instructorChange = summary && previousSummary
+    ? calculateChange(
+        summary.avgInstructorSatisfaction ?? 0,
+        previousSummary.avgInstructorSatisfaction ?? 0
+      )
+    : null;
+
+  const handleInstructorClick = (instructorIdValue: string) => {
+    if (!instructorIdValue) return;
+    navigate(`/dashboard/instructor-details/${instructorIdValue}?year=${selectedYear}`);
   };
 
   const handleShareReport = () => {
-    if (!currentReport) return;
-    
+    if (!summary) return;
     const shareData = {
-      title: `${currentReport.course_title} 과정별 결과 보고서`,
-      text: `${selectedYear}년 ${selectedCourse} 과정의 운영 결과를 확인해보세요.`,
+      title: `${currentCourseName} 과정별 결과 보고서`,
+      text: `${selectedYear}년 ${currentCourseName} 과정의 운영 결과를 확인해보세요.`,
       url: window.location.href,
     };
 
@@ -100,140 +211,67 @@ const CourseReports = () => {
     } else {
       navigator.clipboard.writeText(window.location.href).then(() => {
         toast({
-          title: "링크 복사됨",
-          description: "보고서 링크가 클립보드에 복사되었습니다.",
+          title: '링크 복사됨',
+          description: '보고서 링크가 클립보드에 복사되었습니다.',
         });
       });
     }
   };
 
   const handlePDFExport = () => {
-    const currentReport = reports[0];
-    if (!currentReport) {
+    if (!summary) {
       toast({
-        title: "오류",
-        description: "내보낼 데이터가 없습니다.",
-        variant: "destructive"
+        title: '오류',
+        description: '내보낼 데이터가 없습니다.',
+        variant: 'destructive',
       });
       return;
     }
 
     try {
       generateCourseReportPDF({
-        reportTitle: isInstructor ? '개인 과정별 운영 결과 보고서' : '과정별 운영 결과 보고서',
-        year: currentReport.education_year,
-        round: currentReport.education_round > 0 ? currentReport.education_round : undefined,
-        courseName: currentReport.course_title,
-        totalSurveys: currentReport.total_surveys,
-        totalResponses: currentReport.total_responses,
-        instructorCount: currentReport.report_data?.instructor_count || 0,
-        avgInstructorSatisfaction: currentReport.avg_instructor_satisfaction,
-        avgCourseSatisfaction: currentReport.avg_course_satisfaction,
-        avgOperationSatisfaction: currentReport.report_data?.operation_satisfaction || 0,
-        instructorStats: instructorStats.map(stat => ({
+        reportTitle: hookIsInstructor ? '개인 과정별 운영 결과 보고서' : '과정별 운영 결과 보고서',
+        year: summary.educationYear,
+        round: summary.educationRound ?? undefined,
+        courseName: currentCourseName || '과정 미정',
+        totalSurveys: summary.totalSurveys,
+        totalResponses: summary.totalResponses,
+        instructorCount: summary.instructorCount,
+        avgInstructorSatisfaction: toFixedOrZero(summary.avgInstructorSatisfaction),
+        avgCourseSatisfaction: toFixedOrZero(summary.avgCourseSatisfaction),
+        avgOperationSatisfaction: toFixedOrZero(summary.avgOperationSatisfaction),
+        instructorStats: instructorStatsDisplay.map((stat) => ({
           name: stat.instructor_name,
           surveyCount: stat.survey_count,
           responseCount: stat.response_count,
-          avgSatisfaction: stat.avg_satisfaction
-        }))
+          avgSatisfaction: stat.avg_satisfaction,
+        })),
       });
 
       toast({
-        title: "성공",
-        description: "PDF 파일이 다운로드되었습니다.",
+        title: '성공',
+        description: 'PDF 파일이 다운로드되었습니다.',
       });
     } catch (error) {
-      console.error('PDF export error:', error);
+      console.error('PDF export error', error);
       toast({
-        title: "오류",
-        description: "PDF 내보내기 중 오류가 발생했습니다.",
-        variant: "destructive"
+        title: '오류',
+        description: 'PDF 내보내기 중 오류가 발생했습니다.',
+        variant: 'destructive',
       });
     }
   };
-
-  const years = Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - i);
-  const currentReport = reports[0];
-  const previousReport = previousReports[0];
-
-  const calculateChange = (current: number, previous: number) => {
-    if (!previous || previous === 0) return null;
-    const change = current - previous;
-    const percentage = (change / previous) * 100;
-    return { change, percentage };
-  };
-
-  // 차트용 안전한 데이터 준비
-  const safeCourseStatistics = courseStatistics?.map(stat => ({
-    ...stat,
-    enrolled_count: isNaN(stat.enrolled_count) ? 0 : stat.enrolled_count,
-    total_satisfaction: isNaN(stat.total_satisfaction) || !isFinite(stat.total_satisfaction) ? 0 : stat.total_satisfaction,
-    instructor_satisfaction: isNaN(stat.instructor_satisfaction) || !isFinite(stat.instructor_satisfaction) ? 0 : stat.instructor_satisfaction,
-    course_satisfaction: isNaN(stat.course_satisfaction) || !isFinite(stat.course_satisfaction) ? 0 : stat.course_satisfaction,
-    operation_satisfaction: isNaN(stat.operation_satisfaction) || !isFinite(stat.operation_satisfaction) ? 0 : stat.operation_satisfaction
-  })).filter(stat => stat.enrolled_count > 0 || stat.total_satisfaction > 0) || [];
-
-  const surveyChange = previousReport ? calculateChange(currentReport?.total_surveys || 0, previousReport.total_surveys) : null;
-  const responseChange = previousReport ? calculateChange(currentReport?.total_responses || 0, previousReport.total_responses) : null;
-  const instructorChange = previousReport ? calculateChange(currentReport?.avg_instructor_satisfaction || 0, previousReport.avg_instructor_satisfaction) : null;
-
-  const instructorTrendData = instructorStats
-    .filter(instructor => !isNaN(instructor.avg_satisfaction) && isFinite(instructor.avg_satisfaction) && instructor.avg_satisfaction > 0)
-    .map(instructor => ({
-      name: instructor.instructor_name,
-      만족도: Number(instructor.avg_satisfaction.toFixed(1)) || 0,
-      응답수: instructor.response_count
-    }));
-
-  const satisfactionChartData = currentReport ? [
-    { 
-      name: '강사 만족도', 
-      value: !isNaN(currentReport.avg_instructor_satisfaction) && isFinite(currentReport.avg_instructor_satisfaction) ? Number(currentReport.avg_instructor_satisfaction.toFixed(1)) : 0, 
-      fill: 'hsl(var(--chart-1))' 
-    },
-    { 
-      name: '과목 만족도', 
-      value: !isNaN(currentReport.avg_course_satisfaction) && isFinite(currentReport.avg_course_satisfaction) ? Number(currentReport.avg_course_satisfaction.toFixed(1)) : 0, 
-      fill: 'hsl(var(--chart-2))' 
-    },
-    { 
-      name: '운영 만족도', 
-      value: !isNaN(currentReport.report_data?.operation_satisfaction || 0) && isFinite(currentReport.report_data?.operation_satisfaction || 0) ? Number((currentReport.report_data?.operation_satisfaction || 0).toFixed(1)) : 0, 
-      fill: 'hsl(var(--chart-3))' 
-    }
-  ].filter(item => !isNaN(item.value) && isFinite(item.value) && item.value >= 0) : [];
-
-  const currentRoundData = currentReport ? [
-    { 
-      name: '강사 만족도', 
-      value: !isNaN(currentReport.avg_instructor_satisfaction) ? Number(currentReport.avg_instructor_satisfaction.toFixed(1)) : 0 
-    },
-    { 
-      name: '과목 만족도', 
-      value: !isNaN(currentReport.avg_course_satisfaction) ? Number(currentReport.avg_course_satisfaction.toFixed(1)) : 0 
-    },
-    { 
-      name: '운영 만족도', 
-      value: !isNaN(currentReport.report_data?.operation_satisfaction || 0) ? Number((currentReport.report_data?.operation_satisfaction || 0).toFixed(1)) : 0 
-    }
-  ].filter(item => !isNaN(item.value) && item.value >= 0) : [];
-
-  const overallSatisfaction = currentReport && !isNaN(currentReport.avg_instructor_satisfaction) && !isNaN(currentReport.avg_course_satisfaction) ? 
-    Number(((currentReport.avg_instructor_satisfaction + currentReport.avg_course_satisfaction + (currentReport.report_data?.operation_satisfaction || 0)) / 3).toFixed(1)) || 0 : 0;
-
-  const responseRate = currentReport && currentReport.total_surveys > 0 ? 
-    (currentReport.total_responses / (currentReport.total_surveys * 20)) * 100 : 0;
 
   const openDrillDown = (type: 'instructor' | 'course' | 'operation') => {
     const titles = {
-      instructor: '강사 만족도',
-      course: '과목 만족도', 
-      operation: '운영 만족도'
+      instructor: '강사 만족도 세부 분석',
+      course: '과정 만족도 세부 분석',
+      operation: '운영 만족도 세부 분석',
     };
     setDrillDownModal({ isOpen: true, type, title: titles[type] });
   };
 
-  const actions = currentReport ? (
+  const actions = summary ? (
     <div className="flex items-center gap-2">
       <Button onClick={handleShareReport} variant="outline" size="sm" className="bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100">
         <Share2 className="h-4 w-4 mr-2" />
@@ -246,6 +284,8 @@ const CourseReports = () => {
     </div>
   ) : null;
 
+  const showEmptyState = hookIsInstructor && instructorId && (!summary || summary.totalResponses === 0);
+
   return (
     <DashboardLayout
       title="과정 결과 보고"
@@ -255,7 +295,6 @@ const CourseReports = () => {
       loading={loading}
     >
       <div className="space-y-6">
-        {/* 권한별 알림 섹션 */}
         {isInstructor && (
           <Card className="border-blue-200 bg-blue-50">
             <CardContent className="p-4">
@@ -263,9 +302,7 @@ const CourseReports = () => {
                 <User className="h-5 w-5 text-blue-600" />
                 <div>
                   <h3 className="font-medium text-blue-900">개인 과정 분석</h3>
-                  <p className="text-sm text-blue-700">
-                    회원님이 담당하신 과정들의 만족도 결과만 표시됩니다.
-                  </p>
+                  <p className="text-sm text-blue-700">회원님이 담당하신 과정들의 만족도 결과만 표시됩니다.</p>
                 </div>
               </div>
             </CardContent>
@@ -279,26 +316,21 @@ const CourseReports = () => {
                 <Crown className="h-5 w-5 text-green-600" />
                 <div>
                   <h3 className="font-medium text-green-900">전체 과정 분석</h3>
-                  <p className="text-sm text-green-700">
-                    모든 강사의 과정 결과를 확인하고 비교 분석할 수 있습니다.
-                  </p>
+                  <p className="text-sm text-green-700">모든 강사의 과정 결과를 확인하고 비교 분석할 수 있습니다.</p>
                 </div>
               </div>
             </CardContent>
           </Card>
         )}
 
-        {/* 강사가 데이터가 없을 때 */}
-        {isInstructor && instructorId && reports.length === 0 && !loading && (
+        {showEmptyState && (
           <Card className="border-orange-200 bg-orange-50">
             <CardContent className="p-6 text-center">
               <AlertCircle className="h-12 w-12 text-orange-500 mx-auto mb-4" />
               <h3 className="font-medium text-orange-900 mb-2">설문 데이터가 없습니다</h3>
-              <p className="text-sm text-orange-700 mb-4">
-                아직 담당하신 과정의 설문 결과가 없습니다.
-              </p>
-              <Button 
-                variant="outline" 
+              <p className="text-sm text-orange-700 mb-4">아직 담당하신 과정의 설문 결과가 없습니다.</p>
+              <Button
+                variant="outline"
                 onClick={() => navigate('/dashboard/templates')}
                 className="border-orange-300 text-orange-700 hover:bg-orange-100"
               >
@@ -308,7 +340,6 @@ const CourseReports = () => {
           </Card>
         )}
 
-        {/* 필터 */}
         <CourseSelector
           selectedYear={selectedYear}
           selectedCourse={selectedCourse}
@@ -317,15 +348,15 @@ const CourseReports = () => {
           availableCourses={availableCourses}
           availableRounds={availableRounds}
           availableInstructors={isInstructor ? [] : availableInstructors}
-          years={years}
+          years={YEARS}
           onYearChange={(value) => setSelectedYear(Number(value))}
           onCourseChange={setSelectedCourse}
           onRoundChange={(value) => setSelectedRound(value ? Number(value) : null)}
           onInstructorChange={setSelectedInstructor}
+          testDataToggle={<TestDataToggle testDataOptions={testDataOptions} />}
         />
 
-        {/* 과정 만족도 메인 카드 */}
-        {currentReport && (
+        {summary && (
           <Card className="bg-gradient-to-r from-purple-50 to-indigo-50 border-purple-200 shadow-lg">
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
@@ -339,9 +370,7 @@ const CourseReports = () => {
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-4xl font-bold text-purple-900">
-                    {overallSatisfaction ? overallSatisfaction.toFixed(1) : '0.0'}
-                  </div>
+                  <div className="text-4xl font-bold text-purple-900">{overallSatisfaction.toFixed(1)}</div>
                   <p className="text-sm text-purple-700">점 / 10점 만점</p>
                 </div>
               </div>
@@ -349,283 +378,154 @@ const CourseReports = () => {
           </Card>
         )}
 
-        {/* 상세 통계 카드들 */}
-        {currentReport && (
+        {summary && (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <Card>
+            <Card onClick={() => openDrillDown('course')} className="cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">총 설문</CardTitle>
                 <BookOpen className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">{currentReport.total_surveys}</div>
-                <p className="text-xs text-muted-foreground">
-                  진행된 설문 수
-                </p>
+                <div className="text-2xl font-bold">{summary.totalSurveys}</div>
+                <p className="text-xs text-muted-foreground">진행된 설문 수</p>
+                {surveyChange && (
+                  <p className={`text-xs mt-2 ${surveyChange.change >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {surveyChange.change >= 0 ? '▲' : '▼'} {Math.abs(surveyChange.percentage).toFixed(1)}%
+                  </p>
+                )}
               </CardContent>
             </Card>
 
-            <Card>
+            <Card onClick={() => openDrillDown('course')} className="cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">총 응답</CardTitle>
                 <Target className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">{currentReport.total_responses}</div>
-                <p className="text-xs text-muted-foreground">
-                  수집된 응답 수
-                </p>
+                <div className="text-2xl font-bold">{summary.totalResponses}</div>
+                <p className="text-xs text-muted-foreground">수집된 응답 수</p>
+                {responseChange && (
+                  <p className={`text-xs mt-2 ${responseChange.change >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {responseChange.change >= 0 ? '▲' : '▼'} {Math.abs(responseChange.percentage).toFixed(1)}%
+                  </p>
+                )}
               </CardContent>
             </Card>
 
-            <Card>
+            <Card onClick={() => openDrillDown('instructor')} className="cursor-pointer">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">강사 만족도</CardTitle>
-                <User className="h-4 w-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">
-                  {!isNaN(currentReport.avg_instructor_satisfaction) ? currentReport.avg_instructor_satisfaction.toFixed(1) : '0.0'}
-                </div>
-                <p className="text-xs text-muted-foreground">평균 만족도</p>
-              </CardContent>
-            </Card>
-
-            <Card>
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">과목 만족도</CardTitle>
                 <TrendingUp className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
               <CardContent>
-                <div className="text-2xl font-bold">
-                  {!isNaN(currentReport.avg_course_satisfaction) ? currentReport.avg_course_satisfaction.toFixed(1) : '0.0'}
-                </div>
+                <div className="text-2xl font-bold">{toFixedOrZero(summary.avgInstructorSatisfaction).toFixed(1)}</div>
+                <p className="text-xs text-muted-foreground">평균 만족도</p>
+                {instructorChange && (
+                  <p className={`text-xs mt-2 ${instructorChange.change >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {instructorChange.change >= 0 ? '▲' : '▼'} {Math.abs(instructorChange.percentage).toFixed(1)}%
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card onClick={() => openDrillDown('operation')} className="cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">운영 만족도</CardTitle>
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{toFixedOrZero(summary.avgOperationSatisfaction).toFixed(1)}</div>
                 <p className="text-xs text-muted-foreground">평균 만족도</p>
               </CardContent>
             </Card>
           </div>
         )}
 
-        {/* 만족도 차트 섹션 */}
-        {satisfactionChartData.length > 0 && (
-          <div className="space-y-6">
-            {/* 섹션 헤더 */}
-            <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-lg p-4 border-l-4 border-blue-500">
-              <h2 className="text-lg font-semibold text-blue-700 mb-1 flex items-center gap-2">
+        {summary && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
                 <BarChart3 className="h-5 w-5" />
                 영역별 만족도 비교
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                강사, 과목, 운영 영역별 만족도를 비교 분석합니다
-              </p>
-            </div>
-
-            <Card>
-              <CardHeader className="pb-4">
-                <CardTitle className="text-lg">영역별 만족도 분석</CardTitle>
-                <CardDescription>각 영역별 현재 만족도 현황</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <ReBarChart data={satisfactionChartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-                    <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
-                    <XAxis 
-                      dataKey="name" 
-                      tick={{ fontSize: 12 }}
-                      axisLine={{ stroke: 'hsl(var(--border))' }}
-                    />
-                    <YAxis 
-                      domain={[0, 5]} 
-                      tick={{ fontSize: 12 }}
-                      axisLine={{ stroke: 'hsl(var(--border))' }}
-                    />
-                    <Tooltip 
-                      contentStyle={{
-                        backgroundColor: 'hsl(var(--card))',
-                        border: '1px solid hsl(var(--border))',
-                        borderRadius: '6px',
-                        fontSize: '12px'
-                      }}
-                      formatter={(value: any) => [`${value}점`, '만족도']}
-                    />
-                    <Bar 
-                      dataKey="value" 
-                      fill="hsl(var(--primary))" 
-                      radius={[2, 2, 0, 0]}
-                      maxBarSize={80}
-                    />
-                  </ReBarChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-          </div>
+              </CardTitle>
+              <CardDescription>강사, 과목, 운영 영역별 현재 만족도 현황</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={300}>
+                <ReBarChart data={satisfactionChartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <YAxis domain={[0, 5]} tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <Tooltip
+                    formatter={(value: number) => [`${value.toFixed(1)}점`, '만족도']}
+                    contentStyle={{
+                      backgroundColor: 'hsl(var(--card))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                      fontSize: '12px',
+                    }}
+                  />
+                  <Bar dataKey="value">
+                    {satisfactionChartData.map((item, index) => (
+                      <Cell key={index} fill={item.fill} />
+                    ))}
+                  </Bar>
+                </ReBarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
         )}
 
-        {/* 월별 트렌드 차트 */}
-        {trendData && trendData.length > 0 && (
-          <div className="space-y-6">
-            <div className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-lg p-4 border-l-4 border-green-500">
-              <h2 className="text-lg font-semibold text-green-700 mb-1 flex items-center gap-2">
+        {trendChartData.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
                 <TrendingUp className="h-5 w-5" />
-                월별 트렌드
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                차수별 만족도 변화 추이를 확인합니다
-              </p>
-            </div>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">차수별 만족도 추이</CardTitle>
-                <CardDescription>교육 차수별 만족도 변화 분석</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <ReLineChart data={trendData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-                    <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
-                    <XAxis 
-                      dataKey="round" 
-                      tick={{ fontSize: 12 }}
-                      axisLine={{ stroke: 'hsl(var(--border))' }}
-                    />
-                    <YAxis 
-                      domain={[0, 10]} 
-                      tick={{ fontSize: 12 }}
-                      axisLine={{ stroke: 'hsl(var(--border))' }}
-                    />
-                    <Tooltip 
-                      contentStyle={{
-                        backgroundColor: 'hsl(var(--card))',
-                        border: '1px solid hsl(var(--border))',
-                        borderRadius: '6px',
-                        fontSize: '12px'
-                      }}
-                      formatter={(value: any) => [`${value}점`, '만족도']}
-                    />
-                    <Legend />
-                    <Line 
-                      type="monotone" 
-                      dataKey="강사만족도" 
-                      stroke="hsl(var(--chart-1))" 
-                      strokeWidth={2}
-                      dot={{ r: 4 }}
-                    />
-                    <Line 
-                      type="monotone" 
-                      dataKey="과정만족도" 
-                      stroke="hsl(var(--chart-2))" 
-                      strokeWidth={2}
-                      dot={{ r: 4 }}
-                    />
-                    <Line 
-                      type="monotone" 
-                      dataKey="운영만족도" 
-                      stroke="hsl(var(--chart-3))" 
-                      strokeWidth={2}
-                      dot={{ r: 4 }}
-                    />
-                  </ReLineChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-          </div>
+                차수별 만족도 추이
+              </CardTitle>
+              <CardDescription>최근 차수별 만족도 흐름을 확인합니다</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={320}>
+                <ReLineChart data={trendChartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <YAxis domain={[0, 5]} tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <Tooltip
+                    formatter={(value: number) => [`${value.toFixed(1)}점`, '만족도']}
+                    contentStyle={{
+                      backgroundColor: 'hsl(var(--card))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                      fontSize: '12px',
+                    }}
+                  />
+                  <Legend />
+                  <Line type="monotone" dataKey="강사만족도" stroke="hsl(var(--chart-1))" strokeWidth={2} dot={{ r: 4 }} />
+                  <Line type="monotone" dataKey="과정만족도" stroke="hsl(var(--chart-2))" strokeWidth={2} dot={{ r: 4 }} />
+                  <Line type="monotone" dataKey="운영만족도" stroke="hsl(var(--chart-3))" strokeWidth={2} dot={{ r: 4 }} />
+                </ReLineChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
         )}
 
-        {/* 과정별 통계 차트 */}
-        {safeCourseStatistics && safeCourseStatistics.length > 0 && (
-          <div className="space-y-6">
-            <div className="bg-gradient-to-r from-orange-50 to-amber-50 rounded-lg p-4 border-l-4 border-orange-500">
-              <h2 className="text-lg font-semibold text-orange-700 mb-1 flex items-center gap-2">
-                <BarChart3 className="h-5 w-5" />
-                과정별 통계
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                과정별 수강 및 만족도 통계를 비교합니다
-              </p>
-            </div>
-
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">과정별 수강생 및 만족도</CardTitle>
-                <CardDescription>과정별 운영 현황 및 성과 분석</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={350}>
-                  <ComposedChart data={safeCourseStatistics} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-                    <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
-                    <XAxis 
-                      dataKey="course_name" 
-                      tick={{ fontSize: 12 }}
-                      axisLine={{ stroke: 'hsl(var(--border))' }}
-                      angle={-45}
-                      textAnchor="end"
-                      height={100}
-                    />
-                    <YAxis 
-                      yAxisId="left"
-                      orientation="left"
-                      tick={{ fontSize: 12 }}
-                      axisLine={{ stroke: 'hsl(var(--border))' }}
-                    />
-                    <YAxis 
-                      yAxisId="right"
-                      orientation="right"
-                      domain={[0, 10]}
-                      tick={{ fontSize: 12 }}
-                      axisLine={{ stroke: 'hsl(var(--border))' }}
-                    />
-                    <Tooltip 
-                      contentStyle={{
-                        backgroundColor: 'hsl(var(--card))',
-                        border: '1px solid hsl(var(--border))',
-                        borderRadius: '6px',
-                        fontSize: '12px'
-                      }}
-                    />
-                    <Legend />
-                    <Bar 
-                      yAxisId="left"
-                      dataKey="enrolled_count" 
-                      fill="hsl(var(--chart-1))" 
-                      name="수강생수"
-                      radius={[2, 2, 0, 0]}
-                    />
-                    <Line 
-                      yAxisId="right"
-                      type="monotone" 
-                      dataKey="total_satisfaction" 
-                      stroke="hsl(var(--chart-2))" 
-                      strokeWidth={3}
-                      name="총 만족도"
-                      dot={{ r: 4 }}
-                    />
-                  </ComposedChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-          </div>
-        )}
-
-        {/* 강사 통계 섹션 */}
-        {instructorStats.length > 0 && (
+        {instructorStatsDisplay.length > 0 && (
           <InstructorStatsSection
-            instructorStats={instructorStats}
+            instructorStats={instructorStatsDisplay}
+            previousStats={previousInstructorStatsDisplay}
             onInstructorClick={handleInstructorClick}
           />
         )}
 
-        {/* 키워드 및 의견 분석 섹션 */}
-        {textualResponses && textualResponses.length > 0 && (
-          <KeywordCloud textualResponses={textualResponses} />
-        )}
+        {textualResponses.length > 0 && <KeywordCloud textualResponses={textualResponses} />}
 
-        {/* 드릴다운 모달 */}
         <DrillDownModal
           isOpen={drillDownModal.isOpen}
-          onClose={() => setDrillDownModal({ ...drillDownModal, isOpen: false })}
+          onClose={() => setDrillDownModal((prev) => ({ ...prev, isOpen: false }))}
           title={drillDownModal.title}
           type={drillDownModal.type}
-          instructorStats={instructorStats}
+          instructorStats={instructorStatsDisplay}
           textualResponses={textualResponses}
         />
       </div>

--- a/src/pages/DashboardCourseReports.tsx
+++ b/src/pages/DashboardCourseReports.tsx
@@ -1,30 +1,45 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  BarChart as ReBarChart,
+  LineChart as ReLineChart,
+  Bar,
+  Line,
+  Cell,
+} from 'recharts';
+import { TrendingUp, Download, Star, Target, BarChart3 } from 'lucide-react';
 import { DashboardLayout } from '@/components/layouts';
-import { TrendingUp, Download, Star, Target, Minus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
-import { 
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
-  LineChart, Line, PieChart, Pie, Cell, ComposedChart
-} from 'recharts';
-import { useCourseReportsData } from '@/hooks/useCourseReportsData';
-import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import CourseSelector from '@/components/course-reports/CourseSelector';
 import InstructorStatsSection from '@/components/course-reports/InstructorStatsSection';
-import CourseStatsCards from '@/components/course-reports/CourseStatsCards';
-import { SatisfactionStatusBadge } from '@/components/course-reports/SatisfactionStatusBadge';
-import { DrillDownModal } from '@/components/course-reports/DrillDownModal';
 import { KeywordCloud } from '@/components/course-reports/KeywordCloud';
-import { generateCourseReportPDF } from '@/utils/pdfExport';
-import { useToast } from '@/hooks/use-toast';
-import { useAuth } from '@/hooks/useAuth';
+import { DrillDownModal } from '@/components/course-reports/DrillDownModal';
 import { ManagerInsightCards } from '@/components/dashboard/ManagerInsightCards';
+import { generateCourseReportPDF } from '@/utils/pdfExport';
+import { useCourseReportsData } from '@/hooks/useCourseReportsData';
+import { useToast } from '@/hooks/use-toast';
+import { TestDataToggle } from '@/components/TestDataToggle';
+import { useTestDataToggle } from '@/hooks/useTestDataToggle';
 
-const DashboardCourseReports = () => {
+const CURRENT_YEAR = new Date().getFullYear();
+const YEARS = Array.from({ length: 5 }, (_, index) => CURRENT_YEAR - index);
+
+const toFixedOrZero = (value: number | null | undefined, digits = 1) => {
+  if (typeof value !== 'number' || !isFinite(value)) return 0;
+  const rounded = Number(value.toFixed(digits));
+  return isNaN(rounded) ? 0 : rounded;
+};
+
+const DashboardCourseReports: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear());
+  const [selectedYear, setSelectedYear] = useState<number>(CURRENT_YEAR);
   const [selectedCourse, setSelectedCourse] = useState<string>('');
   const [selectedRound, setSelectedRound] = useState<number | null>(null);
   const [selectedInstructor, setSelectedInstructor] = useState<string>('');
@@ -33,26 +48,29 @@ const DashboardCourseReports = () => {
     type: 'instructor' | 'course' | 'operation';
     title: string;
   }>({ isOpen: false, type: 'instructor', title: '' });
-  
+
   const { toast } = useToast();
-  const { userRoles } = useAuth();
-  
-  const isInstructor = userRoles.includes('instructor');
+  const testDataOptions = useTestDataToggle();
 
   const {
-    reports,
+    summary,
+    previousSummary,
+    trend,
     instructorStats,
     previousInstructorStats,
+    textualResponses,
     availableCourses,
     availableRounds,
     availableInstructors,
-    textualResponses,
     loading,
-    fetchAvailableCourses,
-    fetchReports,
-  } = useCourseReportsData(selectedYear, selectedCourse, selectedRound, selectedInstructor);
+  } = useCourseReportsData(
+    selectedYear,
+    selectedCourse,
+    selectedRound,
+    selectedInstructor,
+    testDataOptions.includeTestData
+  );
 
-  // URL 파라미터 -> 상태 초기화
   useEffect(() => {
     const spYear = searchParams.get('year');
     const spCourse = searchParams.get('course');
@@ -65,7 +83,6 @@ const DashboardCourseReports = () => {
     if (spInstructor) setSelectedInstructor(spInstructor);
   }, []);
 
-  // 상태 -> URL 동기화 (링크 공유/북마크용)
   useEffect(() => {
     const next = new URLSearchParams();
     next.set('year', String(selectedYear));
@@ -73,651 +90,357 @@ const DashboardCourseReports = () => {
     if (selectedRound) next.set('round', String(selectedRound));
     if (selectedInstructor) next.set('instructor', selectedInstructor);
     setSearchParams(next, { replace: true });
-  }, [selectedYear, selectedCourse, selectedRound, selectedInstructor]);
+  }, [selectedYear, selectedCourse, selectedRound, selectedInstructor, setSearchParams]);
 
-  // 초기 데이터 로딩
   useEffect(() => {
-    console.log('DashboardCourseReports: Initial data loading');
-    fetchAvailableCourses();
-  }, [selectedYear]);
+    if (availableCourses.length === 0) return;
+    if (selectedCourse && availableCourses.some((course) => course.normalizedName === selectedCourse)) return;
+    setSelectedCourse(availableCourses[0].normalizedName);
+  }, [availableCourses, selectedCourse]);
 
-  // 필터 변경 시 리포트 다시 가져오기
   useEffect(() => {
-    console.log('DashboardCourseReports: Filters changed, fetching reports');
-    fetchReports();
-  }, [selectedYear, selectedCourse, selectedRound, selectedInstructor]);
+    if (!selectedRound) return;
+    if (!availableRounds.includes(selectedRound)) {
+      setSelectedRound(null);
+    }
+  }, [availableRounds, selectedRound]);
 
-  const handleInstructorClick = (instructorId: string) => {
-    setSelectedInstructor(instructorId);
-  };
+  useEffect(() => {
+    if (!selectedInstructor) return;
+    if (!availableInstructors.some((instructor) => instructor.id === selectedInstructor)) {
+      setSelectedInstructor('');
+    }
+  }, [availableInstructors, selectedInstructor]);
 
-  const handleSatisfactionClick = (type: 'instructor' | 'course' | 'operation') => {
-    const titles = {
-      instructor: '강사 만족도',
-      course: '과목 만족도', 
-      operation: '운영 만족도'
-    };
-    setDrillDownModal({ isOpen: true, type, title: titles[type] });
-  };
+  const currentCourseName = useMemo(() => {
+    if (summary?.courseName) return summary.courseName;
+    const fallback = availableCourses.find((course) => course.normalizedName === selectedCourse);
+    return fallback?.displayName ?? selectedCourse;
+  }, [summary?.courseName, availableCourses, selectedCourse]);
+
+  const satisfactionChartData = useMemo(() => {
+    if (!summary) return [];
+    return [
+      { name: '강사 만족도', value: toFixedOrZero(summary.avgInstructorSatisfaction), fill: 'hsl(var(--chart-1))' },
+      { name: '과정 만족도', value: toFixedOrZero(summary.avgCourseSatisfaction), fill: 'hsl(var(--chart-2))' },
+      { name: '운영 만족도', value: toFixedOrZero(summary.avgOperationSatisfaction), fill: 'hsl(var(--chart-3))' },
+    ];
+  }, [summary]);
+
+  const trendChartData = useMemo(() =>
+    trend
+      .map((point) => ({
+        name: point.educationRound ? `${point.educationRound}차` : '전체',
+        강사만족도: toFixedOrZero(point.avgInstructorSatisfaction),
+        과정만족도: toFixedOrZero(point.avgCourseSatisfaction),
+        운영만족도: toFixedOrZero(point.avgOperationSatisfaction),
+      }))
+      .filter((item) => item.강사만족도 > 0 || item.과정만족도 > 0 || item.운영만족도 > 0),
+    [trend]
+  );
+
+  const instructorStatsDisplay = useMemo(
+    () =>
+      instructorStats.map((stat) => ({
+        instructor_id: stat.instructorId ?? '',
+        instructor_name: stat.instructorName,
+        survey_count: stat.surveyCount,
+        response_count: stat.responseCount,
+        avg_satisfaction: toFixedOrZero(stat.avgSatisfaction),
+      })),
+    [instructorStats]
+  );
+
+  const previousInstructorStatsDisplay = useMemo(
+    () =>
+      previousInstructorStats.map((stat) => ({
+        instructor_id: stat.instructorId ?? '',
+        instructor_name: stat.instructorName,
+        survey_count: stat.surveyCount,
+        response_count: stat.responseCount,
+        avg_satisfaction: toFixedOrZero(stat.avgSatisfaction),
+      })),
+    [previousInstructorStats]
+  );
+
+  const overallSatisfaction = useMemo(() => {
+    if (!summary) return 0;
+    const scores = [
+      summary.avgInstructorSatisfaction,
+      summary.avgCourseSatisfaction,
+      summary.avgOperationSatisfaction,
+    ].map((value) => (typeof value === 'number' && isFinite(value) ? value : null));
+    const validScores = scores.filter((value): value is number => typeof value === 'number');
+    if (validScores.length === 0) return 0;
+    const average = validScores.reduce((acc, value) => acc + value, 0) / validScores.length;
+    return toFixedOrZero(average);
+  }, [summary]);
+
+  const topPerformers = useMemo(
+    () =>
+      instructorStatsDisplay
+        .slice()
+        .sort((a, b) => b.avg_satisfaction - a.avg_satisfaction)
+        .slice(0, 3)
+        .map((stat) => ({
+          name: stat.instructor_name,
+          satisfaction: stat.avg_satisfaction,
+          improvement: 0,
+        })),
+    [instructorStatsDisplay]
+  );
+
+  const lowPerformingCourses = useMemo(() => {
+    if (!summary) return [];
+    const status = overallSatisfaction >= 4.5 ? 'excellent' : overallSatisfaction >= 4 ? 'good' : 'needs-improvement';
+    return [
+      {
+        name: currentCourseName || '선택된 과정',
+        satisfaction: overallSatisfaction,
+        responseCount: summary.totalResponses,
+        status: status as 'excellent' | 'good' | 'needs-improvement',
+      },
+    ];
+  }, [summary, currentCourseName, overallSatisfaction]);
+
+  const comparisonWithPrevious = useMemo(() => {
+    if (!summary || !previousSummary) {
+      return { change: 0, isImproved: true };
+    }
+    const previousOverall = toFixedOrZero(previousSummary.avgInstructorSatisfaction);
+    const change = overallSatisfaction - previousOverall;
+    return { change, isImproved: change >= 0 };
+  }, [summary, previousSummary, overallSatisfaction]);
 
   const handlePDFExport = () => {
-    const currentReport = reports[0];
-    if (!currentReport) {
+    if (!summary) {
       toast({
-        title: "오류",
-        description: "내보낼 데이터가 없습니다.",
-        variant: "destructive"
+        title: '오류',
+        description: '내보낼 데이터가 없습니다.',
+        variant: 'destructive',
       });
       return;
     }
 
     try {
       generateCourseReportPDF({
-        reportTitle: isInstructor ? '개인 과정별 운영 결과 보고서' : '과정별 운영 결과 보고서',
-        year: currentReport.education_year,
-        round: currentReport.education_round > 0 ? currentReport.education_round : undefined,
-        courseName: currentReport.course_title,
-        totalSurveys: currentReport.total_surveys,
-        totalResponses: currentReport.total_responses,
-        instructorCount: currentReport.report_data?.instructor_count || 0,
-        avgInstructorSatisfaction: currentReport.avg_instructor_satisfaction,
-        avgCourseSatisfaction: currentReport.avg_course_satisfaction,
-        avgOperationSatisfaction: currentReport.report_data?.operation_satisfaction || 0,
-        instructorStats: instructorStats.map(stat => ({
+        reportTitle: '과정별 운영 결과 보고서',
+        year: summary.educationYear,
+        round: summary.educationRound ?? undefined,
+        courseName: currentCourseName || '과정 미정',
+        totalSurveys: summary.totalSurveys,
+        totalResponses: summary.totalResponses,
+        instructorCount: summary.instructorCount,
+        avgInstructorSatisfaction: toFixedOrZero(summary.avgInstructorSatisfaction),
+        avgCourseSatisfaction: toFixedOrZero(summary.avgCourseSatisfaction),
+        avgOperationSatisfaction: toFixedOrZero(summary.avgOperationSatisfaction),
+        instructorStats: instructorStatsDisplay.map((stat) => ({
           name: stat.instructor_name,
           surveyCount: stat.survey_count,
           responseCount: stat.response_count,
-          avgSatisfaction: stat.avg_satisfaction
-        }))
+          avgSatisfaction: stat.avg_satisfaction,
+        })),
       });
 
       toast({
-        title: "성공",
-        description: "PDF 파일이 다운로드되었습니다.",
+        title: '성공',
+        description: 'PDF 파일이 다운로드되었습니다.',
       });
     } catch (error) {
-      console.error('PDF export error:', error);
+      console.error('PDF export error', error);
       toast({
-        title: "오류",
-        description: "PDF 내보내기 중 오류가 발생했습니다.",
-        variant: "destructive"
+        title: '오류',
+        description: 'PDF 내보내기 중 오류가 발생했습니다.',
+        variant: 'destructive',
       });
     }
   };
 
-  const years = Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - i);
-  const currentReport = reports[0];
-
-  // 안전한 숫자 변환 함수
-  const safeToFixed = (value: number, digits: number = 1) => {
-    return isNaN(value) || !isFinite(value) ? 0 : Number(value.toFixed(digits));
+  const openDrillDown = (type: 'instructor' | 'course' | 'operation') => {
+    const titles = {
+      instructor: '강사 만족도 세부 분석',
+      course: '과정 만족도 세부 분석',
+      operation: '운영 만족도 세부 분석',
+    };
+    setDrillDownModal({ isOpen: true, type, title: titles[type] });
   };
-
-  // 차트 데이터 구성
-  const satisfactionData = currentReport ? [
-    { 
-      name: '강사', 
-      value: safeToFixed(currentReport.avg_instructor_satisfaction),
-      color: 'hsl(var(--chart-1))',
-      previous: reports[1] ? safeToFixed(reports[1].avg_instructor_satisfaction) : null
-    },
-    { 
-      name: '과정', 
-      value: safeToFixed(currentReport.avg_course_satisfaction),
-      color: 'hsl(var(--chart-2))',
-      previous: reports[1] ? safeToFixed(reports[1].avg_course_satisfaction) : null
-    },
-    { 
-      name: '운영', 
-      value: safeToFixed(currentReport.report_data?.operation_satisfaction || 0),
-      color: 'hsl(var(--chart-3))',
-      previous: reports[1] ? safeToFixed(reports[1].report_data?.operation_satisfaction || 0) : null
-    }
-  ] : [];
-
-  const trendData = reports.map(report => ({
-    name: `${report.education_round}차`,
-    instructor: safeToFixed(report.avg_instructor_satisfaction),
-    course: safeToFixed(report.avg_course_satisfaction),
-    operation: safeToFixed(report.report_data?.operation_satisfaction || 0)
-  })).reverse();
-
-  // 강사별 만족도 데이터 (실제 데이터 연동)
-  const instructorSatisfactionData = instructorStats.map(stat => ({
-    name: stat.instructor_name,
-    satisfaction: safeToFixed(stat.avg_satisfaction),
-    responses: stat.response_count,
-    surveys: stat.survey_count
-  })).sort((a, b) => b.satisfaction - a.satisfaction);
-
-  // 만족도 분포 데이터 (실제 데이터 기반)
-  const satisfactionDistribution = [
-    { 
-      name: '우수 (8-10점)', 
-      value: instructorStats.filter(s => s.avg_satisfaction >= 8).length,
-      fill: 'hsl(var(--chart-1))'
-    },
-    { 
-      name: '보통 (6-8점)', 
-      value: instructorStats.filter(s => s.avg_satisfaction >= 6 && s.avg_satisfaction < 8).length,
-      fill: 'hsl(var(--chart-2))'
-    },
-    { 
-      name: '개선필요 (0-6점)', 
-      value: instructorStats.filter(s => s.avg_satisfaction < 6).length,
-      fill: 'hsl(var(--chart-3))'
-    }
-  ].filter(item => item.value > 0);
-
-  const getSatisfactionIcon = (score: number) => {
-    if (score >= 8) return <Star className="h-4 w-4 text-yellow-500" />;
-    if (score >= 6) return <Target className="h-4 w-4 text-blue-500" />;
-    return <Minus className="h-4 w-4 text-gray-400" />;
-  };
-
-  const actions = currentReport ? (
-    <Button onClick={handlePDFExport} variant="outline" size="sm">
-      <Download className="h-4 w-4 mr-2" />
-      PDF 내보내기
-    </Button>
-  ) : null;
 
   return (
     <DashboardLayout
-      title={isInstructor ? "과정별 결과 보고" : "과정별 결과 보고"}
-      subtitle={isInstructor ? '개인 성과 및 과목별 피드백 분석' : '조직 전체 과정 운영 결과 및 인사이트'}
-      icon={<TrendingUp className="h-5 w-5 text-white" />}
-      actions={actions}
+      title="대시보드 과정 보고"
+      subtitle="조직 전체의 과정 운영 현황을 빠르게 파악하세요"
+      icon={<BarChart3 className="h-5 w-5 text-white" />}
+      actions={
+        summary ? (
+          <Button onClick={handlePDFExport} size="sm" className="bg-primary text-white hover:bg-primary/90 shadow-md">
+            <Download className="h-4 w-4 mr-2" />
+            PDF 다운로드
+          </Button>
+        ) : null
+      }
       loading={loading}
     >
       <div className="space-y-6">
-        {/* 로딩 상태 표시 */}
-        {loading && (
-          <div className="text-center py-8">
-            <div className="text-lg">데이터를 불러오는 중...</div>
-          </div>
-        )}
+        <CourseSelector
+          selectedYear={selectedYear}
+          selectedCourse={selectedCourse}
+          selectedRound={selectedRound}
+          selectedInstructor={selectedInstructor}
+          availableCourses={availableCourses}
+          availableRounds={availableRounds}
+          availableInstructors={availableInstructors}
+          years={YEARS}
+          onYearChange={(value) => setSelectedYear(Number(value))}
+          onCourseChange={setSelectedCourse}
+          onRoundChange={(value) => setSelectedRound(value ? Number(value) : null)}
+          onInstructorChange={setSelectedInstructor}
+          testDataToggle={<TestDataToggle testDataOptions={testDataOptions} />}
+        />
 
-        {/* 필터 */}
-        {!loading && (
-          <CourseSelector
-            selectedYear={selectedYear}
-            selectedCourse={selectedCourse}
-            selectedRound={selectedRound}
-            selectedInstructor={selectedInstructor}
-            availableCourses={availableCourses}
-            availableRounds={availableRounds}
-            availableInstructors={isInstructor ? [] : availableInstructors}
-            years={years}
-            onYearChange={(value) => setSelectedYear(Number(value))}
-            onCourseChange={setSelectedCourse}
-            onRoundChange={(value) => setSelectedRound(value ? Number(value) : null)}
-            onInstructorChange={setSelectedInstructor}
+        {summary && (
+          <ManagerInsightCards
+            topPerformers={topPerformers}
+            lowPerformingCourses={lowPerformingCourses}
+            totalInstructors={summary.instructorCount}
+            avgOrganizationSatisfaction={overallSatisfaction}
+            comparisonWithPrevious={comparisonWithPrevious}
           />
         )}
 
-        {/* 데이터가 없을 때 안내 메시지 */}
-        {!loading && availableCourses.length === 0 && (
-          <div className="text-center py-8">
-            <div className="text-lg text-muted-foreground">설문 데이터가 없습니다.</div>
-            <div className="text-sm text-muted-foreground mt-2">
-              {selectedYear}년도에 완료된 설문이 없습니다. 다른 연도를 선택해보세요.
-            </div>
+        {summary && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <Card onClick={() => openDrillDown('course')} className="cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">총 설문</CardTitle>
+                <Target className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{summary.totalSurveys}</div>
+                <p className="text-xs text-muted-foreground">진행된 설문 수</p>
+              </CardContent>
+            </Card>
+
+            <Card onClick={() => openDrillDown('course')} className="cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">총 응답</CardTitle>
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{summary.totalResponses}</div>
+                <p className="text-xs text-muted-foreground">수집된 응답 수</p>
+              </CardContent>
+            </Card>
+
+            <Card onClick={() => openDrillDown('instructor')} className="cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">강사 만족도</CardTitle>
+                <Star className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{toFixedOrZero(summary.avgInstructorSatisfaction).toFixed(1)}</div>
+                <p className="text-xs text-muted-foreground">평균 만족도</p>
+              </CardContent>
+            </Card>
+
+            <Card onClick={() => openDrillDown('operation')} className="cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">운영 만족도</CardTitle>
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{toFixedOrZero(summary.avgOperationSatisfaction).toFixed(1)}</div>
+                <p className="text-xs text-muted-foreground">평균 만족도</p>
+              </CardContent>
+            </Card>
           </div>
         )}
 
-        {/* 전체 평균 만족도 강조 섹션 */}
-        {!loading && currentReport && (
-          <Card className="bg-gradient-to-r from-primary/10 via-primary/5 to-background border-primary/20">
-            <CardHeader className="text-center pb-4">
-              <CardTitle className="text-lg text-primary">전체 평균 만족도</CardTitle>
-              <CardDescription>강사, 과정, 운영 만족도 종합 점수</CardDescription>
+        {summary && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <BarChart3 className="h-5 w-5" />
+                영역별 만족도 비교
+              </CardTitle>
+              <CardDescription>강사, 과목, 운영 영역별 현재 만족도 현황</CardDescription>
             </CardHeader>
-            <CardContent className="text-center">
-              {(() => {
-                // 0보다 큰 값만 필터링하여 평균 계산
-                const validScores = [
-                  currentReport.avg_instructor_satisfaction,
-                  currentReport.avg_course_satisfaction,
-                  currentReport.report_data?.operation_satisfaction || 0
-                ].filter(score => score > 0);
-                
-                const overallAvg = validScores.length > 0 
-                  ? validScores.reduce((a, b) => a + b, 0) / validScores.length 
-                  : 0;
-                
-                return (
-                  <>
-                    <div className="text-6xl font-bold text-primary mb-4">
-                      {overallAvg.toFixed(1)}
-                    </div>
-                    <div className="text-lg text-muted-foreground mb-4">10점 만점</div>
-                    <div className="flex justify-center">
-                      <SatisfactionStatusBadge score={overallAvg} />
-                    </div>
-                  </>
-                );
-              })()}
+            <CardContent>
+              <ResponsiveContainer width="100%" height={300}>
+                <ReBarChart data={satisfactionChartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <YAxis domain={[0, 5]} tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <Tooltip
+                    formatter={(value: number) => [`${value.toFixed(1)}점`, '만족도']}
+                    contentStyle={{
+                      backgroundColor: 'hsl(var(--card))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                      fontSize: '12px',
+                    }}
+                  />
+                  <Bar dataKey="value">
+                    {satisfactionChartData.map((item, index) => (
+                      <Cell key={index} fill={item.fill} />
+                    ))}
+                  </Bar>
+                </ReBarChart>
+              </ResponsiveContainer>
             </CardContent>
           </Card>
         )}
 
-        {/* 기본 통계 카드 */}
-        {!loading && currentReport && (
-          <CourseStatsCards
-            totalSurveys={currentReport.total_surveys}
-            totalResponses={currentReport.total_responses}
-            instructorCount={currentReport.report_data?.instructor_count || 0}
-            avgSatisfaction={currentReport.avg_instructor_satisfaction}
+        {trendChartData.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <TrendingUp className="h-5 w-5" />
+                차수별 만족도 추이
+              </CardTitle>
+              <CardDescription>최근 차수별 만족도 흐름을 확인합니다</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={320}>
+                <ReLineChart data={trendChartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+                  <XAxis dataKey="name" tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <YAxis domain={[0, 5]} tick={{ fontSize: 12 }} axisLine={{ stroke: 'hsl(var(--border))' }} />
+                  <Tooltip
+                    formatter={(value: number) => [`${value.toFixed(1)}점`, '만족도']}
+                    contentStyle={{
+                      backgroundColor: 'hsl(var(--card))',
+                      border: '1px solid hsl(var(--border))',
+                      borderRadius: '6px',
+                      fontSize: '12px',
+                    }}
+                  />
+                  <Legend />
+                  <Line type="monotone" dataKey="강사만족도" stroke="hsl(var(--chart-1))" strokeWidth={2} dot={{ r: 4 }} />
+                  <Line type="monotone" dataKey="과정만족도" stroke="hsl(var(--chart-2))" strokeWidth={2} dot={{ r: 4 }} />
+                  <Line type="monotone" dataKey="운영만족도" stroke="hsl(var(--chart-3))" strokeWidth={2} dot={{ r: 4 }} />
+                </ReLineChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        )}
+
+        {instructorStatsDisplay.length > 0 && (
+          <InstructorStatsSection
+            instructorStats={instructorStatsDisplay}
+            previousStats={previousInstructorStatsDisplay}
+            onInstructorClick={(id) => setSelectedInstructor(id)}
           />
         )}
 
-        {/* 만족도 점수 카드 */}
-        {!loading && currentReport && (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <Card 
-              className="cursor-pointer hover:shadow-lg transition-shadow"
-              onClick={() => handleSatisfactionClick('instructor')}
-            >
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">강사 만족도</CardTitle>
-                {getSatisfactionIcon(currentReport.avg_instructor_satisfaction)}
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">
-                  {currentReport.avg_instructor_satisfaction.toFixed(1)}
-                </div>
-                <div className="flex items-center space-x-2 mt-2">
-                  <Progress value={currentReport.avg_instructor_satisfaction * 10} className="flex-1" />
-                  <SatisfactionStatusBadge score={currentReport.avg_instructor_satisfaction} />
-                </div>
-              </CardContent>
-            </Card>
+        {textualResponses.length > 0 && <KeywordCloud textualResponses={textualResponses} />}
 
-            <Card 
-              className="cursor-pointer hover:shadow-lg transition-shadow"
-              onClick={() => handleSatisfactionClick('course')}
-            >
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">과목 만족도</CardTitle>
-                {getSatisfactionIcon(currentReport.avg_course_satisfaction)}
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">
-                  {currentReport.avg_course_satisfaction.toFixed(1)}
-                </div>
-                <div className="flex items-center space-x-2 mt-2">
-                  <Progress value={currentReport.avg_course_satisfaction * 10} className="flex-1" />
-                  <SatisfactionStatusBadge score={currentReport.avg_course_satisfaction} />
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card 
-              className="cursor-pointer hover:shadow-lg transition-shadow"
-              onClick={() => handleSatisfactionClick('operation')}
-            >
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">운영 만족도</CardTitle>
-                {getSatisfactionIcon(currentReport.report_data?.operation_satisfaction || 0)}
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">
-                  {(currentReport.report_data?.operation_satisfaction || 0).toFixed(1)}
-                </div>
-                <div className="flex items-center space-x-2 mt-2">
-                  <Progress value={(currentReport.report_data?.operation_satisfaction || 0) * 10} className="flex-1" />
-                  <SatisfactionStatusBadge score={currentReport.report_data?.operation_satisfaction || 0} />
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        )}
-
-        {/* 차트 섹션 */}
-        {!loading && currentReport && (
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* 강사 만족도 분포 도넛 차트 */}
-            <Card 
-              className="cursor-pointer hover:shadow-lg transition-shadow"
-              onClick={() => handleSatisfactionClick('instructor')}
-            >
-              <CardHeader>
-                <CardTitle>강사 만족도 분포</CardTitle>
-                <CardDescription>등급별 강사 수 분포 (클릭하여 상세 정보 보기)</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="h-[300px]">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie
-                        data={satisfactionDistribution}
-                        cx="50%"
-                        cy="50%"
-                        innerRadius={60}
-                        outerRadius={100}
-                        paddingAngle={5}
-                        dataKey="value"
-                      />
-                      <Tooltip 
-                        contentStyle={{
-                          backgroundColor: 'hsl(var(--card))',
-                          border: '1px solid hsl(var(--border))',
-                          borderRadius: '8px',
-                          color: 'hsl(var(--card-foreground))'
-                        }}
-                      />
-                    </PieChart>
-                  </ResponsiveContainer>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* 영역별 만족도 비교 차트 */}
-            <Card
-              className="cursor-pointer hover:shadow-lg transition-shadow"
-              onClick={() => handleSatisfactionClick('course')}
-            >
-              <CardHeader>
-                <CardTitle>영역별 만족도 비교</CardTitle>
-                <CardDescription>
-                  {selectedCourse && selectedRound 
-                    ? `이전 회차 대비 ${selectedRound}차 결과` 
-                    : '전년도 대비 현재 결과'} (클릭하여 상세 데이터 보기)
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={satisfactionData} barCategoryGap="20%">
-                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                    <XAxis dataKey="name" stroke="hsl(var(--foreground))" />
-                    <YAxis domain={[0, 10]} stroke="hsl(var(--foreground))" />
-                    <Tooltip 
-                      contentStyle={{
-                        backgroundColor: 'hsl(var(--card))',
-                        border: '1px solid hsl(var(--border))',
-                        borderRadius: '8px',
-                        color: 'hsl(var(--card-foreground))'
-                      }}
-                      formatter={(value, name, props) => {
-                        const data = props.payload;
-                        const comparisonLabel = selectedCourse && selectedRound 
-                          ? '이전 회차' 
-                          : '전년도';
-                        
-                        if (name === 'value') {
-                          return [
-                            <div key="comparison" className="space-y-1">
-                              <div className="font-semibold">현재: {value}점</div>
-                              {data.previous && (
-                                <div className="text-sm">
-                                  {comparisonLabel}: {data.previous}점
-                                </div>
-                              )}
-                              {data.previous && (
-                                <div className={`text-sm font-medium ${
-                                  Number(value) > Number(data.previous) ? 'text-green-600' : 
-                                  Number(value) < Number(data.previous) ? 'text-red-600' : 'text-gray-600'
-                                }`}>
-                                  {Number(value) > Number(data.previous)
-                                    ? `↗ +${(Number(value) - Number(data.previous)).toFixed(1)}점` 
-                                    : Number(value) < Number(data.previous)
-                                    ? `↘ ${(Number(value) - Number(data.previous)).toFixed(1)}점`
-                                    : '→ 변화없음'}
-                                </div>
-                              )}
-                            </div>,
-                            ''
-                          ];
-                        }
-                        return [`${value}점`, name];
-                      }}
-                    />
-                    <Bar 
-                      dataKey="value" 
-                      fill="hsl(var(--primary))" 
-                      radius={[4, 4, 0, 0]}
-                      maxBarSize={60}
-                    />
-                  </BarChart>
-                </ResponsiveContainer>
-              </CardContent>
-            </Card>
-
-            {/* 강사별 만족도 현황 */}
-            {instructorSatisfactionData.length > 0 && (() => {
-              // 강사 필터가 있을 때는 해당 강사만, 없을 때는 전체 강사 표시
-              const filteredData = selectedInstructor 
-                ? instructorSatisfactionData.filter(item => item.name.includes(selectedInstructor) || item.name === selectedInstructor)
-                : instructorSatisfactionData;
-              
-              // 이전 기간 데이터와 매핑하여 차트 데이터 구성
-              const chartData = filteredData.map(item => {
-                const previousItem = previousInstructorStats.find(prev => 
-                  prev.instructor_name === item.name
-                );
-                
-                return {
-                  name: item.name,
-                  만족도: Math.min(Math.max(Number(item.satisfaction.toFixed(1)), 0), 10),
-                  이전만족도: previousItem ? Math.min(Math.max(Number(previousItem.avg_satisfaction.toFixed(1)), 0), 10) : null,
-                  응답수: item.responses,
-                  설문수: item.surveys,
-                  변화: previousItem ? Number((item.satisfaction - previousItem.avg_satisfaction).toFixed(1)) : null
-                };
-              });
-              
-              // 전체 평균 계산 (현재 기간)
-              const totalAverage = chartData.length > 0 
-                ? chartData.reduce((sum, item) => sum + item.만족도, 0) / chartData.length 
-                : 0;
-              
-              // 이전 기간 평균 계산
-              const previousAverage = chartData.filter(item => item.이전만족도 !== null).length > 0
-                ? chartData.filter(item => item.이전만족도 !== null).reduce((sum, item) => sum + (item.이전만족도 || 0), 0) / chartData.filter(item => item.이전만족도 !== null).length
-                : null;
-
-              return (
-                <Card className="lg:col-span-2">
-                  <CardHeader className="flex flex-row items-center justify-between">
-                    <div>
-                      <CardTitle>강사별 만족도 현황 (10점 만점)</CardTitle>
-                      <CardDescription>
-                        {selectedCourse && selectedRound 
-                          ? `이전 회차 대비 ${selectedRound}차 강사별 만족도 평가` 
-                          : '전년도 대비 강사별 만족도 평가'}
-                      </CardDescription>
-                    </div>
-                    <div className="text-right">
-                      <div className="text-2xl font-bold text-primary">
-                        현재 평균 {totalAverage.toFixed(1)}점
-                      </div>
-                      {previousAverage && (
-                        <div className="text-sm text-muted-foreground">
-                          이전: {previousAverage.toFixed(1)}점 
-                          <span className={`ml-1 font-medium ${
-                            totalAverage > previousAverage ? 'text-green-600' : 
-                            totalAverage < previousAverage ? 'text-red-600' : 'text-gray-600'
-                          }`}>
-                            ({totalAverage > previousAverage ? '+' : ''}{(totalAverage - previousAverage).toFixed(1)})
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="mb-4 flex flex-wrap gap-4 text-sm">
-                      <div className="flex items-center gap-2">
-                        <div className="w-3 h-3 rounded-sm bg-[hsl(var(--chart-1))]"></div>
-                        <span>현재 만족도</span>
-                      </div>
-                      {previousAverage && (
-                        <div className="flex items-center gap-2">
-                          <div className="w-3 h-3 rounded-sm bg-[hsl(var(--chart-2))]"></div>
-                          <span>이전 만족도</span>
-                        </div>
-                      )}
-                      <div className="text-xs text-muted-foreground">
-                        {selectedInstructor ? `선택된 강사: ${selectedInstructor}` : '전체 강사 표시'}
-                        {previousAverage && ` | 비교 기준: ${selectedCourse && selectedRound ? '이전 회차' : '전년도'}`}
-                      </div>
-                    </div>
-                    
-                    <ResponsiveContainer width="100%" height={400}>
-                      <ComposedChart 
-                        data={chartData}
-                        margin={{ top: 20, right: 30, left: 20, bottom: 40 }}
-                        barCategoryGap="20%"
-                      >
-                        <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.3} />
-                        <XAxis 
-                          dataKey="name" 
-                          stroke="hsl(var(--foreground))" 
-                          fontSize={12}
-                          angle={-45}
-                          textAnchor="end"
-                          height={80}
-                        />
-                        <YAxis 
-                          domain={[6, 10]} 
-                          stroke="hsl(var(--foreground))" 
-                          fontSize={12}
-                          tickCount={5}
-                        />
-                         <Tooltip 
-                          contentStyle={{
-                            backgroundColor: 'hsl(var(--card))',
-                            border: '1px solid hsl(var(--border))',
-                            borderRadius: '8px',
-                            color: 'hsl(var(--card-foreground))',
-                            fontSize: '14px'
-                          }}
-                           formatter={(value, name, props) => {
-                            const data = props.payload;
-                            if (!data) return null;
-                            
-                            return [
-                              <div key="tooltip" className="space-y-1">
-                                <div className="font-semibold text-primary border-b pb-1 mb-2">
-                                  <strong>강사명:</strong> {data.name}
-                                </div>
-                                <div>
-                                  <strong>과목명:</strong> {selectedCourse || '전체'}
-                                </div>
-                                <div className="text-lg font-bold text-primary bg-primary/10 px-2 py-1 rounded">
-                                  <strong>종합 만족도:</strong> {data.만족도}점
-                                </div>
-                                <div>
-                                  <strong>과목 만족도:</strong> {data.만족도}점
-                                </div>
-                                <div>
-                                  <strong>강사 만족도:</strong> {data.만족도}점
-                                </div>
-                                {data.이전만족도 && (
-                                  <div className="pt-2 border-t">
-                                    <div>
-                                      <strong>이전 만족도:</strong> {data.이전만족도}점
-                                    </div>
-                                    <div className={`font-medium ${
-                                      data.변화 > 0 ? 'text-green-600' : 
-                                      data.변화 < 0 ? 'text-red-600' : 'text-gray-600'
-                                    }`}>
-                                      <strong>변화:</strong> {data.변화 > 0 ? '+' : ''}{data.변화}점 
-                                      {data.변화 > 0 ? '↗' : data.변화 < 0 ? '↘' : '→'}
-                                    </div>
-                                  </div>
-                                )}
-                                <div className="text-sm text-muted-foreground pt-1 border-t">
-                                  응답수: {data.응답수} / 설문수: {data.설문수}
-                                </div>
-                              </div>,
-                              ''
-                            ];
-                           }}
-                         />
-                        
-                        <Bar 
-                          dataKey="만족도" 
-                          fill="hsl(var(--chart-1))" 
-                          radius={[2, 2, 0, 0]}
-                          maxBarSize={previousAverage ? 30 : 40}
-                          name="현재"
-                        />
-                        
-                        {/* 이전 기간 비교 바 추가 */}
-                        {previousAverage && (
-                          <Bar 
-                            dataKey="이전만족도" 
-                            fill="hsl(var(--chart-2))" 
-                            radius={[2, 2, 0, 0]}
-                            maxBarSize={30}
-                            name="이전"
-                          />
-                        )}
-                        
-                        {/* 추세선 추가 */}
-                        <Line 
-                          type="monotone"
-                          dataKey="만족도"
-                          stroke="hsl(var(--primary))"
-                          strokeWidth={2}
-                          dot={{ fill: 'hsl(var(--primary))', strokeWidth: 2, r: 4 }}
-                          connectNulls={false}
-                        />
-                      </ComposedChart>
-                    </ResponsiveContainer>
-                  </CardContent>
-                </Card>
-              );
-            })()}
-
-            {/* 트렌드 차트 */}
-            {trendData.length > 1 && (
-              <Card className="lg:col-span-2">
-                <CardHeader>
-                  <CardTitle>만족도 트렌드</CardTitle>
-                  <CardDescription>차수별 만족도 변화</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ResponsiveContainer width="100%" height={300}>
-                    <LineChart data={trendData}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                      <XAxis dataKey="name" stroke="hsl(var(--foreground))" />
-                      <YAxis domain={[0, 10]} stroke="hsl(var(--foreground))" />
-                      <Tooltip 
-                        contentStyle={{
-                          backgroundColor: 'hsl(var(--card))',
-                          border: '1px solid hsl(var(--border))',
-                          borderRadius: '8px',
-                          color: 'hsl(var(--card-foreground))'
-                        }}
-                      />
-                      <Line type="monotone" dataKey="instructor" stroke="hsl(var(--chart-1))" strokeWidth={3} name="강사" />
-                      <Line type="monotone" dataKey="course" stroke="hsl(var(--chart-2))" strokeWidth={3} name="과정" />
-                      <Line type="monotone" dataKey="operation" stroke="hsl(var(--chart-3))" strokeWidth={3} name="운영" />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </CardContent>
-              </Card>
-            )}
-          </div>
-        )}
-
-
-        {/* 키워드 클라우드 */}
-        {!loading && textualResponses.length > 0 && (
-          <KeywordCloud textualResponses={textualResponses} />
-        )}
-
-        {/* 드릴다운 모달 */}
         <DrillDownModal
           isOpen={drillDownModal.isOpen}
-          onClose={() => setDrillDownModal({ ...drillDownModal, isOpen: false })}
+          onClose={() => setDrillDownModal((prev) => ({ ...prev, isOpen: false }))}
           title={drillDownModal.title}
           type={drillDownModal.type}
-          instructorStats={instructorStats}
+          instructorStats={instructorStatsDisplay}
           textualResponses={textualResponses}
-          periodData={trendData}
         />
       </div>
     </DashboardLayout>

--- a/src/repositories/courseReportsRepository.ts
+++ b/src/repositories/courseReportsRepository.ts
@@ -1,0 +1,146 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface CourseReportFilters {
+  year: number;
+  courseName?: string | null;
+  round?: number | null;
+  instructorId?: string | null;
+  includeTestData?: boolean;
+}
+
+export interface CourseReportSummary {
+  educationYear: number;
+  courseName: string | null;
+  normalizedCourseName: string | null;
+  educationRound: number | null;
+  instructorId: string | null;
+  availableRounds: number[];
+  totalSurveys: number;
+  totalResponses: number;
+  avgInstructorSatisfaction: number | null;
+  avgCourseSatisfaction: number | null;
+  avgOperationSatisfaction: number | null;
+  instructorCount: number;
+}
+
+export interface CourseTrendPoint {
+  educationRound: number | null;
+  avgInstructorSatisfaction: number | null;
+  avgCourseSatisfaction: number | null;
+  avgOperationSatisfaction: number | null;
+  responseCount: number;
+}
+
+export interface CourseInstructorStat {
+  instructorId: string | null;
+  instructorName: string;
+  surveyCount: number;
+  responseCount: number;
+  avgSatisfaction: number | null;
+}
+
+export interface CourseOption {
+  normalizedName: string;
+  displayName: string;
+  rounds: number[];
+}
+
+export interface CourseReportStatisticsResponse {
+  summary: CourseReportSummary;
+  trend: CourseTrendPoint[];
+  instructorStats: CourseInstructorStat[];
+  textualResponses: string[];
+  availableCourses: CourseOption[];
+  availableInstructors: { id: string; name: string }[];
+}
+
+export const CourseReportsRepository = {
+  async fetchStatistics(filters: CourseReportFilters): Promise<CourseReportStatisticsResponse | null> {
+    const { data, error } = await supabase.rpc('course_report_statistics', {
+      p_year: filters.year,
+      p_course_name: filters.courseName ?? null,
+      p_round: filters.round ?? null,
+      p_instructor_id: filters.instructorId ?? null,
+      p_include_test: filters.includeTestData ?? false,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    const summary = {
+      educationYear: data.summary?.educationYear ?? filters.year,
+      courseName: data.summary?.courseName ?? null,
+      normalizedCourseName: data.summary?.normalizedCourseName ?? null,
+      educationRound: data.summary?.educationRound ?? null,
+      instructorId: data.summary?.instructorId ?? null,
+      availableRounds: Array.isArray(data.summary?.availableRounds)
+        ? data.summary.availableRounds.filter((value: unknown): value is number => typeof value === 'number')
+        : [],
+      totalSurveys: Number(data.summary?.totalSurveys ?? 0),
+      totalResponses: Number(data.summary?.totalResponses ?? 0),
+      avgInstructorSatisfaction: data.summary?.avgInstructorSatisfaction ?? null,
+      avgCourseSatisfaction: data.summary?.avgCourseSatisfaction ?? null,
+      avgOperationSatisfaction: data.summary?.avgOperationSatisfaction ?? null,
+      instructorCount: Number(data.summary?.instructorCount ?? 0),
+    } satisfies CourseReportSummary;
+
+    const trend: CourseTrendPoint[] = Array.isArray(data.trend)
+      ? data.trend.map((item: any) => ({
+          educationRound: typeof item.educationRound === 'number' ? item.educationRound : null,
+          avgInstructorSatisfaction: typeof item.avgInstructorSatisfaction === 'number' ? item.avgInstructorSatisfaction : null,
+          avgCourseSatisfaction: typeof item.avgCourseSatisfaction === 'number' ? item.avgCourseSatisfaction : null,
+          avgOperationSatisfaction: typeof item.avgOperationSatisfaction === 'number' ? item.avgOperationSatisfaction : null,
+          responseCount: Number(item.responseCount ?? 0),
+        }))
+      : [];
+
+    const instructorStats: CourseInstructorStat[] = Array.isArray(data.instructorStats)
+      ? data.instructorStats.map((item: any) => ({
+          instructorId: typeof item.instructorId === 'string' || item.instructorId === null ? item.instructorId : String(item.instructorId ?? ''),
+          instructorName: typeof item.instructorName === 'string' ? item.instructorName : '강사 정보 없음',
+          surveyCount: Number(item.surveyCount ?? 0),
+          responseCount: Number(item.responseCount ?? 0),
+          avgSatisfaction: typeof item.avgSatisfaction === 'number' ? item.avgSatisfaction : null,
+        }))
+      : [];
+
+    const textualResponses: string[] = Array.isArray(data.textualResponses)
+      ? data.textualResponses.filter((value: unknown): value is string => typeof value === 'string' && value.trim().length > 0)
+      : [];
+
+    const availableCourses: CourseOption[] = Array.isArray(data.availableCourses)
+      ? data.availableCourses
+          .map((item: any) => ({
+            normalizedName: typeof item.normalizedName === 'string' ? item.normalizedName : '',
+            displayName: typeof item.displayName === 'string' ? item.displayName : '',
+            rounds: Array.isArray(item.rounds)
+              ? item.rounds.filter((value: unknown): value is number => typeof value === 'number')
+              : [],
+          }))
+          .filter((item) => item.normalizedName.length > 0 || item.displayName.length > 0)
+      : [];
+
+    const availableInstructors = Array.isArray(data.availableInstructors)
+      ? data.availableInstructors
+          .map((item: any) => ({
+            id: typeof item.id === 'string' ? item.id : String(item.id ?? ''),
+            name: typeof item.name === 'string' ? item.name : '강사 정보 없음',
+          }))
+          .filter((item) => item.id && item.id !== 'null')
+      : [];
+
+    return {
+      summary,
+      trend,
+      instructorStats,
+      textualResponses,
+      availableCourses,
+      availableInstructors,
+    };
+  },
+};

--- a/supabase/migrations/20250921120000_create_course_report_statistics.sql
+++ b/supabase/migrations/20250921120000_create_course_report_statistics.sql
@@ -1,0 +1,355 @@
+-- Create helper function to normalize course names similarly to the client logic
+CREATE OR REPLACE FUNCTION public.normalize_course_name(p_name text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  v_name text := COALESCE(p_name, '');
+BEGIN
+  -- Remove "(홀수조)" / "(짝수조)"
+  v_name := REGEXP_REPLACE(v_name, '\\((?:홀수조|짝수조)\\)', '', 'gi');
+  -- Remove patterns like "11/12조"
+  v_name := REGEXP_REPLACE(v_name, '\\b\\d{1,2}/\\d{1,2}조\\b', '', 'gi');
+  -- Remove trailing 조 표기 that follows 차수-일차 descriptions
+  v_name := REGEXP_REPLACE(v_name, '(\\d+차-\\d+일차)\\s+\\d{1,2}조', '\\1', 'gi');
+  v_name := REGEXP_REPLACE(v_name, '(\\d+차-\\d+일차)\\s+(?:홀수조|짝수조)', '\\1', 'gi');
+  -- Remove standalone 조/반 suffixes
+  v_name := REGEXP_REPLACE(v_name, '\\b\\d{1,2}\\s*(?:조|반)\\b', '', 'gi');
+  -- Remove prefixes like "홀수조-" / "짝수조-"
+  v_name := REGEXP_REPLACE(v_name, '(?:홀수조|짝수조)-', '', 'gi');
+  -- Clean up extra spaces and hyphens
+  v_name := REGEXP_REPLACE(v_name, '\\s{2,}', ' ', 'g');
+  v_name := REGEXP_REPLACE(v_name, '-{2,}', '-', 'g');
+  RETURN TRIM(v_name);
+END;
+$$;
+
+-- Stored procedure that aggregates course report statistics
+CREATE OR REPLACE FUNCTION public.course_report_statistics(
+  p_year integer,
+  p_course_name text DEFAULT NULL,
+  p_round integer DEFAULT NULL,
+  p_instructor_id uuid DEFAULT NULL,
+  p_include_test boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  result jsonb;
+  target_course text;
+BEGIN
+  WITH base_surveys AS (
+    SELECT
+      s.*,
+      public.normalize_course_name(s.course_name) AS normalized_course_name
+    FROM public.surveys s
+    WHERE s.education_year = p_year
+      AND s.status IN ('completed', 'active')
+      AND (p_include_test OR COALESCE(s.is_test, false) = false)
+  ),
+  initial_course AS (
+    SELECT MIN(normalized_course_name) AS normalized_course_name
+    FROM base_surveys
+  )
+  SELECT ic.normalized_course_name INTO target_course
+  FROM initial_course ic;
+
+  IF p_course_name IS NOT NULL AND LENGTH(TRIM(p_course_name)) > 0 THEN
+    target_course := public.normalize_course_name(p_course_name);
+  END IF;
+
+  WITH base_surveys AS (
+    SELECT
+      s.*,
+      public.normalize_course_name(s.course_name) AS normalized_course_name
+    FROM public.surveys s
+    WHERE s.education_year = p_year
+      AND s.status IN ('completed', 'active')
+      AND (p_include_test OR COALESCE(s.is_test, false) = false)
+  ),
+  base_instructor_links AS (
+    SELECT s.id AS survey_id, s.instructor_id
+    FROM base_surveys s
+    WHERE s.instructor_id IS NOT NULL
+    UNION
+    SELECT si.survey_id, si.instructor_id
+    FROM public.survey_instructors si
+    JOIN base_surveys s ON s.id = si.survey_id
+    WHERE si.instructor_id IS NOT NULL
+    UNION
+    SELECT ss.survey_id, ss.instructor_id
+    FROM public.survey_sessions ss
+    JOIN base_surveys s ON s.id = ss.survey_id
+    WHERE ss.instructor_id IS NOT NULL
+  ),
+  filtered_surveys AS (
+    SELECT bs.*
+    FROM base_surveys bs
+    WHERE (target_course IS NULL OR bs.normalized_course_name = target_course)
+      AND (p_round IS NULL OR bs.education_round = p_round)
+      AND (
+        p_instructor_id IS NULL OR EXISTS (
+          SELECT 1
+          FROM base_instructor_links bil
+          WHERE bil.survey_id = bs.id
+            AND bil.instructor_id = p_instructor_id
+        )
+      )
+  ),
+  filtered_instructor_links AS (
+    SELECT DISTINCT bil.survey_id, bil.instructor_id
+    FROM base_instructor_links bil
+    JOIN filtered_surveys fs ON fs.id = bil.survey_id
+  ),
+  instructor_info AS (
+    SELECT
+      fil.survey_id,
+      fil.instructor_id,
+      COALESCE(i.name, '강사 정보 없음') AS instructor_name
+    FROM filtered_instructor_links fil
+    LEFT JOIN public.instructors i ON i.id = fil.instructor_id
+  ),
+  survey_instructor_counts AS (
+    SELECT survey_id, COUNT(DISTINCT instructor_id) AS instructor_count
+    FROM filtered_instructor_links
+    GROUP BY survey_id
+  ),
+  single_instructor_map AS (
+    SELECT sic.survey_id, MIN(fil.instructor_id) AS instructor_id
+    FROM survey_instructor_counts sic
+    JOIN filtered_instructor_links fil ON fil.survey_id = sic.survey_id
+    WHERE sic.instructor_count = 1
+    GROUP BY sic.survey_id
+  ),
+  session_instructor_map AS (
+    SELECT ss.id AS session_id, ss.survey_id, ss.instructor_id
+    FROM public.survey_sessions ss
+    JOIN filtered_surveys fs ON fs.id = ss.survey_id
+    WHERE ss.instructor_id IS NOT NULL
+  ),
+  responses AS (
+    SELECT sr.*
+    FROM public.survey_responses sr
+    JOIN filtered_surveys fs ON fs.id = sr.survey_id
+    WHERE p_include_test OR COALESCE(sr.is_test, false) = false
+  ),
+  answers AS (
+    SELECT
+      qa.id,
+      qa.response_id,
+      qa.answer_value,
+      qa.answer_text,
+      qa.created_at,
+      sq.question_type,
+      sq.satisfaction_type,
+      sq.session_id,
+      r.survey_id
+    FROM public.question_answers qa
+    JOIN responses r ON r.id = qa.response_id
+    JOIN public.survey_questions sq ON sq.id = qa.question_id
+  ),
+  numeric_answers AS (
+    SELECT
+      a.*,
+      NULLIF(trim(both '"' FROM COALESCE(a.answer_text, a.answer_value::text)), '') AS answer_string
+    FROM answers a
+  ),
+  scored_answers AS (
+    SELECT
+      na.survey_id,
+      na.response_id,
+      na.question_type,
+      na.satisfaction_type,
+      na.session_id,
+      CASE
+        WHEN na.question_type IN ('scale', 'rating')
+             AND na.answer_string ~ '^[0-9]+(\\.[0-9]+)?$'
+        THEN CASE
+          WHEN (na.answer_string)::numeric <= 0 THEN NULL
+          WHEN (na.answer_string)::numeric <= 5 THEN (na.answer_string)::numeric * 2
+          ELSE (na.answer_string)::numeric
+        END
+        ELSE NULL
+      END AS score
+    FROM numeric_answers na
+  ),
+  scored_with_instructors AS (
+    SELECT
+      sa.*,
+      COALESCE(sim.instructor_id, sim2.instructor_id) AS target_instructor_id
+    FROM scored_answers sa
+    LEFT JOIN session_instructor_map sim ON sim.session_id = sa.session_id
+    LEFT JOIN single_instructor_map sim2 ON sim2.survey_id = sa.survey_id
+  ),
+  available_courses_pre AS (
+    SELECT
+      bs.normalized_course_name,
+      MIN(bs.course_name) AS display_name,
+      ARRAY_AGG(DISTINCT bs.education_round ORDER BY bs.education_round) AS rounds
+    FROM base_surveys bs
+    GROUP BY bs.normalized_course_name
+  ),
+  available_courses_json AS (
+    SELECT COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'normalizedName', ac.normalized_course_name,
+        'displayName', ac.display_name,
+        'rounds', to_jsonb(COALESCE(ac.rounds, ARRAY[]::integer[]))
+      )
+      ORDER BY ac.display_name
+    ), '[]'::jsonb) AS data
+    FROM available_courses_pre ac
+  ),
+  available_instructors_json AS (
+    SELECT COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', fi.instructor_id,
+        'name', COALESCE(i.name, '강사 정보 없음')
+      )
+      ORDER BY COALESCE(i.name, '강사 정보 없음')
+    ), '[]'::jsonb) AS data
+    FROM (
+      SELECT DISTINCT instructor_id
+      FROM filtered_instructor_links
+    ) fi
+    LEFT JOIN public.instructors i ON i.id = fi.instructor_id
+  ),
+  trend_json AS (
+    SELECT COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'educationRound', td.education_round,
+        'avgInstructorSatisfaction', td.avg_instructor,
+        'avgCourseSatisfaction', td.avg_course,
+        'avgOperationSatisfaction', td.avg_operation,
+        'responseCount', td.response_count
+      )
+      ORDER BY td.education_round
+    ), '[]'::jsonb) AS data
+    FROM (
+      SELECT
+        fs.education_round,
+        AVG(CASE
+          WHEN swi.satisfaction_type = 'instructor'
+               AND (p_instructor_id IS NULL OR swi.target_instructor_id = p_instructor_id)
+          THEN swi.score
+        END) AS avg_instructor,
+        AVG(CASE WHEN swi.satisfaction_type = 'course' THEN swi.score END) AS avg_course,
+        AVG(CASE WHEN swi.satisfaction_type = 'operation' THEN swi.score END) AS avg_operation,
+        COUNT(DISTINCT r.id) AS response_count
+      FROM filtered_surveys fs
+      LEFT JOIN responses r ON r.survey_id = fs.id
+      LEFT JOIN scored_with_instructors swi ON swi.response_id = r.id
+      GROUP BY fs.education_round
+    ) td
+  ),
+  instructor_stats_json AS (
+    SELECT COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'instructorId', ist.instructor_id,
+        'instructorName', ist.instructor_name,
+        'surveyCount', ist.survey_count,
+        'responseCount', ist.response_count,
+        'avgSatisfaction', ist.avg_satisfaction
+      )
+      ORDER BY ist.avg_satisfaction DESC NULLS LAST
+    ), '[]'::jsonb) AS data
+    FROM (
+      SELECT
+        fil.instructor_id,
+        COALESCE(MAX(ii.instructor_name), '강사 정보 없음') AS instructor_name,
+        COUNT(DISTINCT fs.id) AS survey_count,
+        COUNT(DISTINCT CASE WHEN swi.target_instructor_id = fil.instructor_id THEN swi.response_id END) AS response_count,
+        AVG(CASE WHEN swi.target_instructor_id = fil.instructor_id THEN swi.score END) AS avg_satisfaction
+      FROM filtered_instructor_links fil
+      JOIN filtered_surveys fs ON fs.id = fil.survey_id
+      LEFT JOIN instructor_info ii ON ii.survey_id = fil.survey_id AND ii.instructor_id = fil.instructor_id
+      LEFT JOIN responses r ON r.survey_id = fs.id
+      LEFT JOIN scored_with_instructors swi ON swi.response_id = r.id
+      GROUP BY fil.instructor_id
+    ) ist
+  ),
+  textual_json AS (
+    SELECT COALESCE(jsonb_agg(ta.text_value ORDER BY ta.text_value), '[]'::jsonb) AS data
+    FROM (
+      SELECT DISTINCT NULLIF(trim(both '"' FROM COALESCE(a.answer_text, a.answer_value::text)), '') AS text_value
+      FROM answers a
+      WHERE a.question_type IN ('text', 'textarea', 'long_text', 'long_textarea', 'paragraph', 'long_answer')
+        AND NULLIF(trim(both '"' FROM COALESCE(a.answer_text, a.answer_value::text)), '') IS NOT NULL
+    ) ta
+  ),
+  summary_values AS (
+    SELECT
+      COALESCE((SELECT COUNT(DISTINCT fs.id) FROM filtered_surveys fs), 0) AS total_surveys,
+      COALESCE((SELECT COUNT(DISTINCT r.id) FROM responses r), 0) AS total_responses,
+      (SELECT AVG(swi.score)
+       FROM scored_with_instructors swi
+       WHERE swi.satisfaction_type = 'instructor'
+         AND (p_instructor_id IS NULL OR swi.target_instructor_id = p_instructor_id)) AS avg_instructor,
+      (SELECT AVG(swi.score)
+       FROM scored_with_instructors swi
+       WHERE swi.satisfaction_type = 'course') AS avg_course,
+      (SELECT AVG(swi.score)
+       FROM scored_with_instructors swi
+       WHERE swi.satisfaction_type = 'operation') AS avg_operation,
+      COALESCE((SELECT COUNT(DISTINCT instructor_id) FROM filtered_instructor_links), 0) AS instructor_count,
+      (SELECT MIN(fs.course_name) FROM filtered_surveys fs) AS course_name,
+      (SELECT MIN(fs.normalized_course_name) FROM filtered_surveys fs) AS normalized_course_name,
+      COALESCE((SELECT ARRAY_AGG(DISTINCT fs.education_round ORDER BY fs.education_round)
+                FROM filtered_surveys fs), ARRAY[]::integer[]) AS available_rounds
+  )
+  SELECT jsonb_build_object(
+    'summary', jsonb_build_object(
+      'educationYear', p_year,
+      'courseName', sv.course_name,
+      'normalizedCourseName', sv.normalized_course_name,
+      'educationRound', p_round,
+      'instructorId', p_instructor_id,
+      'availableRounds', to_jsonb(sv.available_rounds),
+      'totalSurveys', sv.total_surveys,
+      'totalResponses', sv.total_responses,
+      'avgInstructorSatisfaction', sv.avg_instructor,
+      'avgCourseSatisfaction', sv.avg_course,
+      'avgOperationSatisfaction', sv.avg_operation,
+      'instructorCount', sv.instructor_count
+    ),
+    'trend', tj.data,
+    'instructorStats', isj.data,
+    'textualResponses', txj.data,
+    'availableCourses', acj.data,
+    'availableInstructors', aij.data
+  )
+  INTO result
+  FROM summary_values sv
+  CROSS JOIN trend_json tj
+  CROSS JOIN instructor_stats_json isj
+  CROSS JOIN textual_json txj
+  CROSS JOIN available_courses_json acj
+  CROSS JOIN available_instructors_json aij;
+
+  RETURN COALESCE(result, jsonb_build_object(
+    'summary', jsonb_build_object(
+      'educationYear', p_year,
+      'courseName', NULL,
+      'normalizedCourseName', NULL,
+      'educationRound', p_round,
+      'instructorId', p_instructor_id,
+      'availableRounds', to_jsonb(ARRAY[]::integer[]),
+      'totalSurveys', 0,
+      'totalResponses', 0,
+      'avgInstructorSatisfaction', NULL,
+      'avgCourseSatisfaction', NULL,
+      'avgOperationSatisfaction', NULL,
+      'instructorCount', 0
+    ),
+    'trend', '[]'::jsonb,
+    'instructorStats', '[]'::jsonb,
+    'textualResponses', '[]'::jsonb,
+    'availableCourses', '[]'::jsonb,
+    'availableInstructors', '[]'::jsonb
+  ));
+END;
+$$;
+
+COMMENT ON FUNCTION public.course_report_statistics IS 'Returns aggregated course report metrics (responses, satisfaction scores, instructor stats, trend, text responses) for a given set of filters.';


### PR DESCRIPTION
## Summary
- add a course_report_statistics stored procedure to normalize course names and pre-aggregate course report metrics
- provide a repository and hook that call the procedure so course report views consume a single API payload
- refactor course report screens to the new response shape, simplify charts, and surface the test data toggle in shared filters

## Testing
- npm run lint *(fails: missing @eslint/js package in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd6036e5dc832485fc65287b5bcc36