### PR TITLE
feat: add survey cumulative stats view and virtualized dashboard

### DIFF
--- a/src/hooks/useCumulativeSurveyStats.ts
+++ b/src/hooks/useCumulativeSurveyStats.ts
@@ -1,0 +1,253 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type SurveyCumulativeRow,
+  fetchCumulativeExportData,
+  fetchCumulativeFilters,
+  fetchCumulativeStats,
+  fetchCumulativeSummary,
+  type CumulativeSummary,
+} from '@/repositories/cumulativeStatsRepo';
+
+interface UseCumulativeSurveyStatsOptions {
+  includeTestData: boolean;
+  pageSize?: number;
+}
+
+interface UseCumulativeSurveyStatsResult {
+  data: SurveyCumulativeRow[];
+  loading: boolean;
+  loadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  totalCount: number;
+  summary: CumulativeSummary;
+  searchTerm: string;
+  setSearchTerm: (value: string) => void;
+  selectedYear: number | null;
+  setSelectedYear: (value: number | null) => void;
+  selectedCourse: string | null;
+  setSelectedCourse: (value: string | null) => void;
+  availableYears: number[];
+  availableCourses: string[];
+  refresh: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  getExportData: () => Promise<SurveyCumulativeRow[]>;
+}
+
+const DEFAULT_SUMMARY: CumulativeSummary = {
+  totalSurveys: 0,
+  totalResponses: 0,
+  averageSatisfaction: null,
+  participatingInstructors: 0,
+  coursesInProgress: 0,
+};
+
+export function useCumulativeSurveyStats({
+  includeTestData,
+  pageSize = 50,
+}: UseCumulativeSurveyStatsOptions): UseCumulativeSurveyStatsResult {
+  const [data, setData] = useState<SurveyCumulativeRow[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [loadingMore, setLoadingMore] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState<boolean>(false);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [summary, setSummary] = useState<CumulativeSummary>(DEFAULT_SUMMARY);
+
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [debouncedSearch, setDebouncedSearch] = useState<string>('');
+  const [selectedYear, setSelectedYearState] = useState<number | null>(null);
+  const [selectedCourse, setSelectedCourseState] = useState<string | null>(null);
+
+  const [availableYears, setAvailableYears] = useState<number[]>([]);
+  const [availableCourses, setAvailableCourses] = useState<string[]>([]);
+  const coursesByYearRef = useRef<Record<number, string[]>>({});
+  const allCoursesRef = useRef<string[]>([]);
+
+  const [page, setPage] = useState<number>(1);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebouncedSearch(searchTerm.trim());
+    }, 300);
+
+    return () => clearTimeout(handle);
+  }, [searchTerm]);
+
+  const appliedFilters = useMemo(
+    () => ({
+      searchTerm: debouncedSearch,
+      educationYear: selectedYear,
+      courseName: selectedCourse,
+    }),
+    [debouncedSearch, selectedYear, selectedCourse]
+  );
+
+  const refreshFilters = useCallback(async () => {
+    try {
+      const filterData = await fetchCumulativeFilters(includeTestData);
+      coursesByYearRef.current = filterData.coursesByYear;
+      setAvailableYears(filterData.years);
+
+      allCoursesRef.current = filterData.allCourses;
+
+      const nextCourses = selectedYear
+        ? filterData.coursesByYear[selectedYear] ?? []
+        : filterData.allCourses;
+
+      setAvailableCourses([...nextCourses]);
+
+      if (selectedYear && !filterData.years.includes(selectedYear)) {
+        setSelectedYearState(null);
+      }
+
+      if (selectedCourse && !nextCourses.includes(selectedCourse)) {
+        setSelectedCourseState(null);
+      }
+    } catch (err) {
+      console.error('Failed to fetch cumulative filter data', err);
+    }
+  }, [includeTestData, selectedCourse, selectedYear]);
+
+  useEffect(() => {
+    refreshFilters();
+  }, [refreshFilters]);
+
+  useEffect(() => {
+    if (selectedYear) {
+      const nextCourses = coursesByYearRef.current[selectedYear] ?? [];
+      setAvailableCourses([...nextCourses]);
+      if (selectedCourse && !nextCourses.includes(selectedCourse)) {
+        setSelectedCourseState(null);
+      }
+      return;
+    }
+
+    const nextCourses = allCoursesRef.current;
+    setAvailableCourses([...nextCourses]);
+    if (selectedCourse && !nextCourses.includes(selectedCourse)) {
+      setSelectedCourseState(null);
+    }
+  }, [selectedYear, selectedCourse]);
+
+  const loadSummary = useCallback(async () => {
+    try {
+      const result = await fetchCumulativeSummary({
+        includeTestData,
+        searchTerm: appliedFilters.searchTerm,
+        educationYear: appliedFilters.educationYear,
+        courseName: appliedFilters.courseName,
+      });
+      setSummary(result);
+    } catch (err) {
+      console.error('Failed to fetch cumulative summary', err);
+      setSummary(DEFAULT_SUMMARY);
+    }
+  }, [appliedFilters, includeTestData]);
+
+    const loadPage = useCallback(
+      async (pageNumber: number, append = false) => {
+        setError(null);
+        if (append) {
+          setLoadingMore(true);
+        } else {
+        setLoading(true);
+      }
+
+      try {
+        const { data: rows, count } = await fetchCumulativeStats({
+          page: pageNumber,
+          pageSize,
+          includeTestData,
+          searchTerm: appliedFilters.searchTerm,
+          educationYear: appliedFilters.educationYear,
+          courseName: appliedFilters.courseName,
+        });
+
+        const total = count ?? 0;
+        setTotalCount(total);
+
+        if (append) {
+          setData((prev) => {
+            const nextData = [...prev, ...rows];
+            const shouldHaveMore = rows.length === pageSize && nextData.length < total;
+            setHasMore(shouldHaveMore);
+            return nextData;
+          });
+        } else {
+          setData(rows);
+          const shouldHaveMore = rows.length === pageSize && rows.length < total;
+          setHasMore(shouldHaveMore);
+        }
+
+        setPage(pageNumber + 1);
+      } catch (err) {
+        console.error('Failed to fetch cumulative stats', err);
+        setError('데이터를 불러오는데 실패했습니다.');
+        if (!append) {
+          setData([]);
+          setTotalCount(0);
+          setHasMore(false);
+        }
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+        }
+      },
+      [appliedFilters, includeTestData, pageSize]
+    );
+
+  const refresh = useCallback(async () => {
+    setPage(1);
+    await loadPage(1, false);
+    await loadSummary();
+  }, [loadPage, loadSummary]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const loadMore = useCallback(async () => {
+    if (loading || loadingMore || !hasMore) return;
+    await loadPage(page, true);
+  }, [hasMore, loadPage, loading, loadingMore, page]);
+
+  const getExportData = useCallback(async () => {
+    return fetchCumulativeExportData({
+      includeTestData,
+      searchTerm: appliedFilters.searchTerm,
+      educationYear: appliedFilters.educationYear,
+      courseName: appliedFilters.courseName,
+      pageSize: Math.max(pageSize, 200),
+    });
+  }, [appliedFilters, includeTestData, pageSize]);
+
+  const handleSetYear = useCallback((year: number | null) => {
+    setSelectedYearState(year);
+  }, []);
+
+  const handleSetCourse = useCallback((course: string | null) => {
+    setSelectedCourseState(course);
+  }, []);
+
+  return {
+    data,
+    loading,
+    loadingMore,
+    error,
+    hasMore,
+    totalCount,
+    summary,
+    searchTerm,
+    setSearchTerm,
+    selectedYear,
+    setSelectedYear: handleSetYear,
+    selectedCourse,
+    setSelectedCourse: handleSetCourse,
+    availableYears,
+    availableCourses,
+    refresh,
+    loadMore,
+    getExportData,
+  };
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2160,6 +2160,42 @@ export type Database = {
         }
         Relationships: []
       }
+      survey_cumulative_stats: {
+        Row: {
+          avg_course_satisfaction_real: number | null
+          avg_course_satisfaction_test: number | null
+          avg_course_satisfaction_total: number | null
+          avg_instructor_satisfaction_real: number | null
+          avg_instructor_satisfaction_test: number | null
+          avg_instructor_satisfaction_total: number | null
+          avg_operation_satisfaction_real: number | null
+          avg_operation_satisfaction_test: number | null
+          avg_operation_satisfaction_total: number | null
+          avg_satisfaction_real: number | null
+          avg_satisfaction_test: number | null
+          avg_satisfaction_total: number | null
+          course_name: string | null
+          created_at: string | null
+          education_round: number | null
+          education_year: number | null
+          expected_participants: number | null
+          instructor_count: number | null
+          instructor_names: string[] | null
+          instructor_names_text: string | null
+          last_response_at: string | null
+          real_response_count: number | null
+          status: string | null
+          survey_id: string | null
+          survey_is_test: boolean | null
+          test_response_count: number | null
+          title: string | null
+          total_response_count: number | null
+          weighted_satisfaction_real: number | null
+          weighted_satisfaction_test: number | null
+          weighted_satisfaction_total: number | null
+        }
+        Relationships: []
+      }
       surveys_list_v1: {
         Row: {
           combined_round_end: number | null
@@ -2380,6 +2416,21 @@ export type Database = {
           table_name: string
           using_expression: string
           with_check: string
+        }[]
+      }
+      get_survey_cumulative_summary: {
+        Args: {
+          search_term?: string | null
+          education_year?: number | null
+          course_name?: string | null
+          include_test_data?: boolean | null
+        }
+        Returns: {
+          average_satisfaction: number | null
+          courses_in_progress: number
+          participating_instructors: number
+          total_responses: number
+          total_surveys: number
         }[]
       }
       get_session_statistics: {

--- a/src/repositories/cumulativeStatsRepo.ts
+++ b/src/repositories/cumulativeStatsRepo.ts
@@ -1,0 +1,220 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+
+export type SurveyCumulativeRow = Database['public']['Views']['survey_cumulative_stats']['Row'];
+
+type SurveyCumulativeQueryBuilder = ReturnType<typeof supabase.from<'survey_cumulative_stats'>>;
+
+export interface CumulativeStatsQuery {
+  page: number;
+  pageSize: number;
+  searchTerm?: string | null;
+  educationYear?: number | null;
+  courseName?: string | null;
+  includeTestData: boolean;
+}
+
+export interface CumulativeStatsResult {
+  data: SurveyCumulativeRow[];
+  count: number;
+}
+
+export interface CumulativeSummary {
+  totalSurveys: number;
+  totalResponses: number;
+  averageSatisfaction: number | null;
+  participatingInstructors: number;
+  coursesInProgress: number;
+}
+
+export interface CumulativeFilterResult {
+  years: number[];
+  allCourses: string[];
+  coursesByYear: Record<number, string[]>;
+}
+
+function applyFilters(
+  query: SurveyCumulativeQueryBuilder,
+  {
+    searchTerm,
+    educationYear,
+    courseName,
+    includeTestData,
+  }: Pick<CumulativeStatsQuery, 'searchTerm' | 'educationYear' | 'courseName' | 'includeTestData'>
+) {
+  let filtered = query;
+
+  if (!includeTestData) {
+    filtered = filtered.or('survey_is_test.is.false,survey_is_test.is.null');
+  }
+
+  if (educationYear !== null && educationYear !== undefined) {
+    filtered = filtered.eq('education_year', educationYear);
+  }
+
+  if (courseName !== null && courseName !== undefined) {
+    filtered = filtered.eq('course_name', courseName);
+  }
+
+  if (searchTerm && searchTerm.trim()) {
+    const like = `%${searchTerm.trim()}%`;
+    filtered = filtered.or(
+      [
+        `title.ilike.${like}`,
+        `course_name.ilike.${like}`,
+        `instructor_names_text.ilike.${like}`,
+      ].join(',')
+    );
+  }
+
+  return filtered;
+}
+
+export async function fetchCumulativeStats({
+  page,
+  pageSize,
+  searchTerm,
+  educationYear,
+  courseName,
+  includeTestData,
+}: CumulativeStatsQuery): Promise<CumulativeStatsResult> {
+  const safePage = Math.max(1, page);
+  const safePageSize = Math.max(1, pageSize);
+  const from = (safePage - 1) * safePageSize;
+  const to = from + safePageSize - 1;
+
+  let query = supabase
+    .from('survey_cumulative_stats')
+    .select('*', { count: 'exact' })
+    .order('education_year', { ascending: false, nullsLast: true })
+    .order('education_round', { ascending: false, nullsLast: true })
+    .order('title', { ascending: true, nullsLast: true });
+
+  query = applyFilters(query, {
+    searchTerm,
+    educationYear,
+    courseName,
+    includeTestData,
+  });
+
+  const { data, error, count } = await query.range(from, to);
+  if (error) throw error;
+
+  return {
+    data: data ?? [],
+    count: count ?? 0,
+  };
+}
+
+export async function fetchCumulativeSummary({
+  searchTerm,
+  educationYear,
+  courseName,
+  includeTestData,
+}: Omit<CumulativeStatsQuery, 'page' | 'pageSize'>): Promise<CumulativeSummary> {
+  const { data, error } = await supabase.rpc('get_survey_cumulative_summary', {
+    search_term: searchTerm?.trim() || null,
+    education_year: educationYear ?? null,
+    course_name: courseName ?? null,
+    include_test_data: includeTestData,
+  });
+
+  if (error) throw error;
+
+  const summary = Array.isArray(data) ? data[0] : data;
+
+  return {
+    totalSurveys: summary?.total_surveys ?? 0,
+    totalResponses: summary?.total_responses ?? 0,
+    averageSatisfaction: summary?.average_satisfaction ?? null,
+    participatingInstructors: summary?.participating_instructors ?? 0,
+    coursesInProgress: summary?.courses_in_progress ?? 0,
+  };
+}
+
+export async function fetchCumulativeFilters(includeTestData: boolean): Promise<CumulativeFilterResult> {
+  let query = supabase
+    .from('survey_cumulative_stats')
+    .select('education_year, course_name, survey_is_test')
+    .order('education_year', { ascending: false, nullsLast: true })
+    .order('course_name', { ascending: true, nullsLast: true });
+
+  if (!includeTestData) {
+    query = query.or('survey_is_test.is.false,survey_is_test.is.null');
+  }
+
+  const { data, error } = await query;
+  if (error) throw error;
+
+  const yearSet = new Set<number>();
+  const courseMap = new Map<number, Set<string>>();
+  const allCoursesSet = new Set<string>();
+
+  (data ?? []).forEach((row) => {
+    if (row.education_year !== null && row.education_year !== undefined) {
+      yearSet.add(row.education_year);
+      if (!courseMap.has(row.education_year)) {
+        courseMap.set(row.education_year, new Set<string>());
+      }
+
+      if (row.course_name) {
+        courseMap.get(row.education_year)?.add(row.course_name);
+      }
+    }
+
+    if (row.course_name) {
+      allCoursesSet.add(row.course_name);
+    }
+  });
+
+  const coursesByYear: Record<number, string[]> = {};
+  courseMap.forEach((courses, year) => {
+    coursesByYear[year] = Array.from(courses).sort((a, b) => a.localeCompare(b));
+  });
+
+  return {
+    years: Array.from(yearSet).sort((a, b) => b - a),
+    allCourses: Array.from(allCoursesSet).sort((a, b) => a.localeCompare(b)),
+    coursesByYear,
+  };
+}
+
+export async function fetchCumulativeExportData(
+  params: Omit<CumulativeStatsQuery, 'page' | 'pageSize'> & { pageSize?: number }
+): Promise<SurveyCumulativeRow[]> {
+  const {
+    searchTerm,
+    educationYear,
+    courseName,
+    includeTestData,
+    pageSize: requestedPageSize,
+  } = params;
+
+  const pageSize = Math.max(50, requestedPageSize ?? 200);
+  let page = 1;
+  let hasMore = true;
+  const results: SurveyCumulativeRow[] = [];
+
+  while (hasMore) {
+    const { data, count } = await fetchCumulativeStats({
+      page,
+      pageSize,
+      searchTerm,
+      educationYear,
+      courseName,
+      includeTestData,
+    });
+
+    results.push(...data);
+
+    const expectedTotal = count ?? results.length;
+    hasMore = results.length < expectedTotal && data.length === pageSize;
+    page += 1;
+
+    if (!data.length) {
+      break;
+    }
+  }
+
+  return results;
+}

--- a/src/utils/satisfaction.ts
+++ b/src/utils/satisfaction.ts
@@ -1,0 +1,26 @@
+export function convertToTenScale(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return null;
+  }
+
+  return value > 0 && value <= 5 ? value * 2 : value;
+}
+
+interface FormatOptions {
+  digits?: number;
+  fallback?: string;
+  convert?: boolean;
+}
+
+export function formatSatisfaction(
+  value: number | null | undefined,
+  { digits = 1, fallback = '-', convert = false }: FormatOptions = {}
+): string {
+  const normalized = convert ? convertToTenScale(value) : value;
+
+  if (normalized === null || normalized === undefined || Number.isNaN(normalized)) {
+    return fallback;
+  }
+
+  return Number(normalized).toFixed(digits);
+}

--- a/supabase/migrations/20250921020000_create_survey_cumulative_stats_view.sql
+++ b/supabase/migrations/20250921020000_create_survey_cumulative_stats_view.sql
@@ -1,0 +1,175 @@
+-- Create or replace the survey cumulative statistics view with precomputed
+-- response counts, satisfaction averages (converted to a 10-point scale), and
+-- instructor aggregations so the application can query a single dataset.
+DROP VIEW IF EXISTS public.survey_cumulative_stats;
+DROP FUNCTION IF EXISTS public.get_survey_cumulative_summary(text, integer, text, boolean);
+
+CREATE VIEW public.survey_cumulative_stats AS
+WITH instructor_union AS (
+  SELECT s.id AS survey_id, i.name AS instructor_name
+  FROM public.surveys s
+  LEFT JOIN public.instructors i ON i.id = s.instructor_id
+  WHERE i.name IS NOT NULL
+
+  UNION
+
+  SELECT ss.survey_id, i2.name AS instructor_name
+  FROM public.survey_sessions ss
+  LEFT JOIN public.instructors i2 ON i2.id = ss.instructor_id
+  WHERE i2.name IS NOT NULL
+),
+instructor_agg AS (
+  SELECT
+    survey_id,
+    ARRAY_AGG(DISTINCT instructor_name) AS instructor_names,
+    ARRAY_TO_STRING(ARRAY_AGG(DISTINCT instructor_name), ', ') AS instructor_names_text,
+    COUNT(DISTINCT instructor_name) AS instructor_count
+  FROM instructor_union
+  GROUP BY survey_id
+),
+score_data AS (
+  SELECT
+    s.id AS survey_id,
+    sr.id AS response_id,
+    COALESCE(sr.is_test, false) AS is_test_response,
+    sq.satisfaction_type,
+    CASE
+      WHEN qa.answer_value::text ~ '^[0-9]+(\.[0-9]+)?$'
+           AND sq.question_type IN ('scale', 'rating')
+      THEN CASE
+        WHEN (qa.answer_value::text)::numeric <= 5
+          THEN (qa.answer_value::text)::numeric * 2
+        ELSE (qa.answer_value::text)::numeric
+      END
+      ELSE NULL
+    END AS satisfaction_score
+  FROM public.surveys s
+  LEFT JOIN public.survey_responses sr ON sr.survey_id = s.id
+  LEFT JOIN public.question_answers qa ON qa.response_id = sr.id
+  LEFT JOIN public.survey_questions sq ON sq.id = qa.question_id
+)
+SELECT
+  s.id AS survey_id,
+  s.title,
+  s.education_year,
+  s.education_round,
+  s.course_name,
+  s.status,
+  s.expected_participants,
+  s.created_at,
+  s.is_test AS survey_is_test,
+  COALESCE(ia.instructor_names, ARRAY[]::text[]) AS instructor_names,
+  COALESCE(ia.instructor_names_text, '') AS instructor_names_text,
+  COALESCE(ia.instructor_count, 0) AS instructor_count,
+  COUNT(DISTINCT sr.id) AS total_response_count,
+  COUNT(DISTINCT CASE WHEN sd.is_test_response = false THEN sr.id END) AS real_response_count,
+  COUNT(DISTINCT CASE WHEN sd.is_test_response = true THEN sr.id END) AS test_response_count,
+  MAX(sr.submitted_at) AS last_response_at,
+  AVG(sd.satisfaction_score) AS avg_satisfaction_total,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.is_test_response = false) AS avg_satisfaction_real,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.is_test_response = true) AS avg_satisfaction_test,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'course') AS avg_course_satisfaction_total,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'course' AND sd.is_test_response = false) AS avg_course_satisfaction_real,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'course' AND sd.is_test_response = true) AS avg_course_satisfaction_test,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'instructor') AS avg_instructor_satisfaction_total,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'instructor' AND sd.is_test_response = false) AS avg_instructor_satisfaction_real,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'instructor' AND sd.is_test_response = true) AS avg_instructor_satisfaction_test,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'operation') AS avg_operation_satisfaction_total,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'operation' AND sd.is_test_response = false) AS avg_operation_satisfaction_real,
+  AVG(sd.satisfaction_score) FILTER (WHERE sd.satisfaction_type = 'operation' AND sd.is_test_response = true) AS avg_operation_satisfaction_test,
+  COALESCE(COUNT(DISTINCT sr.id)::numeric * COALESCE(AVG(sd.satisfaction_score), 0), 0) AS weighted_satisfaction_total,
+  COALESCE(
+    COUNT(DISTINCT CASE WHEN sd.is_test_response = false THEN sr.id END)::numeric
+      * COALESCE(AVG(sd.satisfaction_score) FILTER (WHERE sd.is_test_response = false), 0),
+    0
+  ) AS weighted_satisfaction_real,
+  COALESCE(
+    COUNT(DISTINCT CASE WHEN sd.is_test_response = true THEN sr.id END)::numeric
+      * COALESCE(AVG(sd.satisfaction_score) FILTER (WHERE sd.is_test_response = true), 0),
+    0
+  ) AS weighted_satisfaction_test
+FROM public.surveys s
+LEFT JOIN public.survey_responses sr ON sr.survey_id = s.id
+LEFT JOIN score_data sd ON sd.response_id = sr.id
+LEFT JOIN instructor_agg ia ON ia.survey_id = s.id
+WHERE s.status IN ('completed', 'active')
+GROUP BY
+  s.id,
+  s.title,
+  s.education_year,
+  s.education_round,
+  s.course_name,
+  s.status,
+  s.expected_participants,
+  s.created_at,
+  s.is_test,
+  ia.instructor_names,
+  ia.instructor_names_text,
+  ia.instructor_count;
+
+COMMENT ON VIEW public.survey_cumulative_stats IS
+  'Aggregated survey-level response counts, satisfaction averages, and instructor metadata for cumulative dashboards.';
+
+CREATE OR REPLACE FUNCTION public.get_survey_cumulative_summary(
+  search_term text DEFAULT NULL,
+  education_year integer DEFAULT NULL,
+  course_name text DEFAULT NULL,
+  include_test_data boolean DEFAULT false
+)
+RETURNS TABLE (
+  total_surveys bigint,
+  total_responses bigint,
+  average_satisfaction numeric,
+  participating_instructors bigint,
+  courses_in_progress bigint
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH filtered AS (
+    SELECT
+      scs.*,
+      CASE
+        WHEN include_test_data THEN COALESCE(scs.total_response_count, 0)
+        ELSE COALESCE(scs.real_response_count, 0)
+      END AS effective_response_count,
+      CASE
+        WHEN include_test_data THEN COALESCE(scs.weighted_satisfaction_total, 0)
+        ELSE COALESCE(scs.weighted_satisfaction_real, 0)
+      END AS effective_weighted_satisfaction
+    FROM public.survey_cumulative_stats scs
+    WHERE
+      (education_year IS NULL OR scs.education_year = education_year)
+      AND (course_name IS NULL OR scs.course_name = course_name)
+      AND (
+        include_test_data
+        OR COALESCE(scs.survey_is_test, false) = false
+      )
+      AND (
+        search_term IS NULL OR search_term = ''
+        OR scs.title ILIKE '%' || search_term || '%'
+        OR scs.course_name ILIKE '%' || search_term || '%'
+        OR scs.instructor_names_text ILIKE '%' || search_term || '%'
+      )
+  ),
+  instructor_set AS (
+    SELECT DISTINCT TRIM(BOTH FROM instructor_name) AS instructor_name
+    FROM filtered
+    CROSS JOIN LATERAL UNNEST(COALESCE(filtered.instructor_names, ARRAY[]::text[])) AS instructor_name
+    WHERE instructor_name IS NOT NULL AND instructor_name <> ''
+  )
+  SELECT
+    COUNT(*)::bigint AS total_surveys,
+    COALESCE(SUM(effective_response_count), 0)::bigint AS total_responses,
+    CASE
+      WHEN COALESCE(SUM(effective_response_count), 0) > 0
+        THEN ROUND(SUM(effective_weighted_satisfaction) / NULLIF(SUM(effective_response_count), 0), 1)
+      ELSE NULL
+    END AS average_satisfaction,
+    (SELECT COUNT(*)::bigint FROM instructor_set) AS participating_instructors,
+    COUNT(DISTINCT filtered.course_name)::bigint AS courses_in_progress
+  FROM filtered;
+$$;
+
+COMMENT ON FUNCTION public.get_survey_cumulative_summary(text, integer, text, boolean) IS
+  'Returns summary metrics for the survey_cumulative_stats view after applying dashboard filters.';


### PR DESCRIPTION
## Summary
- add the survey_cumulative_stats view and summary function to pre-compute responses, satisfaction scores, and instructor aggregates with test data awareness
- introduce a repository, hook, and shared satisfaction utilities so the cumulative dashboard can paginate Supabase results instead of issuing N+1 queries
- refactor CumulativeDataTable to use the new virtualized table, aggregated filters/summary cards, and CSV export derived from the pre-computed data

## Testing
- npm run lint *(fails: missing dependencies because npm install is blocked by a 403 from the npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_68cd605e8c608324a9fe39dd216f803e