### PR TITLE
Ensure Pretendard is primary sans font

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -31,24 +31,27 @@ export default {
 		},
 		extend: {
 			// 한글 폰트 패밀리 추가
-			fontFamily: {
-				sans: [
-					'"Noto Sans KR"',
-					'"Malgun Gothic"',
-					'"Apple SD Gothic Neo"',
-					'"Helvetica Neue"',
-					'Helvetica',
-					'Arial',
-					'sans-serif'
-				],
-				display: [
-					'"Noto Sans KR"',
-					'"Malgun Gothic"',
-					'"Apple SD Gothic Neo"',
-					'system-ui',
-					'sans-serif'
-				]
-			},
+                        fontFamily: {
+                                sans: [
+                                        'Pretendard',
+                                        'Noto Sans KR',
+                                        'Malgun Gothic',
+                                        'Apple SD Gothic Neo',
+                                        'Helvetica Neue',
+                                        'Helvetica',
+                                        'Arial',
+                                        'system-ui',
+                                        'sans-serif'
+                                ],
+                                display: [
+                                        'Pretendard',
+                                        'Noto Sans KR',
+                                        'Malgun Gothic',
+                                        'Apple SD Gothic Neo',
+                                        'system-ui',
+                                        'sans-serif'
+                                ]
+                        },
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- prioritize Pretendard across Tailwind's sans and display font stacks
- retain Korean-focused fallbacks to keep typography consistent

## Testing
- npm run lint *(fails: missing @eslint/js dependency due to npm registry 403 while installing tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_68cd69acb5fc8324b1fafeef934eff07