### PR TITLE
feat: add RPC-backed survey detail analysis

### DIFF
--- a/src/hooks/useSurveyDetailStats.ts
+++ b/src/hooks/useSurveyDetailStats.ts
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  SURVEY_DETAIL_DEFAULTS,
+  SurveyDetailRepository,
+  SurveyDetailResponse,
+  SurveyDetailSummary,
+  SurveyQuestionDistribution,
+  SurveyTextAnswer,
+} from '@/repositories/surveyDetailRepository';
+
+interface UseSurveyDetailStatsOptions {
+  surveyId?: string;
+  includeTestData?: boolean;
+  autoFetch?: boolean;
+}
+
+interface GroupedTextAnswers {
+  questionId: string;
+  questionText: string;
+  satisfactionType: string | null;
+  orderIndex: number | null;
+  answers: SurveyTextAnswer[];
+}
+
+interface UseSurveyDetailStatsResult {
+  summary: SurveyDetailSummary | null;
+  responses: SurveyDetailResponse[];
+  responsesTotal: number;
+  hasMoreResponses: boolean;
+  responsesLoading: boolean;
+  loadMoreResponses: () => Promise<void>;
+  distributions: SurveyQuestionDistribution[];
+  distributionsTotal: number;
+  hasMoreDistributions: boolean;
+  distributionsLoading: boolean;
+  loadMoreDistributions: () => Promise<void>;
+  textAnswers: SurveyTextAnswer[];
+  groupedTextAnswers: GroupedTextAnswers[];
+  textAnswersTotal: number;
+  hasMoreTextAnswers: boolean;
+  textAnswersLoading: boolean;
+  loadMoreTextAnswers: () => Promise<void>;
+  initialLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useSurveyDetailStats(options: UseSurveyDetailStatsOptions): UseSurveyDetailStatsResult {
+  const { surveyId, includeTestData = false, autoFetch = true } = options;
+
+  const [summary, setSummary] = useState<SurveyDetailSummary | null>(null);
+
+  const [responses, setResponses] = useState<SurveyDetailResponse[]>([]);
+  const [responseCursor, setResponseCursor] = useState<number | null>(null);
+  const [responseTotal, setResponseTotal] = useState(0);
+  const [responsesLoading, setResponsesLoading] = useState(false);
+
+  const [distributions, setDistributions] = useState<SurveyQuestionDistribution[]>([]);
+  const [distributionCursor, setDistributionCursor] = useState<number | null>(null);
+  const [distributionTotal, setDistributionTotal] = useState(0);
+  const [distributionsLoading, setDistributionsLoading] = useState(false);
+
+  const [textAnswers, setTextAnswers] = useState<SurveyTextAnswer[]>([]);
+  const [textCursor, setTextCursor] = useState<number | null>(null);
+  const [textTotal, setTextTotal] = useState(0);
+  const [textLoading, setTextLoading] = useState(false);
+
+  const [initialLoading, setInitialLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const resetState = useCallback(() => {
+    setSummary(null);
+
+    setResponses([]);
+    setResponseCursor(null);
+    setResponseTotal(0);
+
+    setDistributions([]);
+    setDistributionCursor(null);
+    setDistributionTotal(0);
+
+    setTextAnswers([]);
+    setTextCursor(null);
+    setTextTotal(0);
+
+    setError(null);
+  }, []);
+
+  const fetchInitial = useCallback(async () => {
+    if (!surveyId) return;
+
+    setInitialLoading(true);
+    setError(null);
+
+    try {
+      const result = await SurveyDetailRepository.fetchSurveyDetailStats({
+        surveyId,
+        includeTestData,
+        responseCursor: 0,
+        distributionCursor: 0,
+        textCursor: 0,
+        responseLimit: SURVEY_DETAIL_DEFAULTS.responseLimit,
+        distributionLimit: SURVEY_DETAIL_DEFAULTS.distributionLimit,
+        textLimit: SURVEY_DETAIL_DEFAULTS.textLimit,
+      });
+
+      setSummary(result.summary);
+
+      setResponses(result.responses.items);
+      setResponseCursor(result.responses.nextCursor ?? null);
+      setResponseTotal(result.responses.totalCount);
+
+      setDistributions(result.distributions.items);
+      setDistributionCursor(result.distributions.nextCursor ?? null);
+      setDistributionTotal(result.distributions.totalCount);
+
+      setTextAnswers(result.textAnswers.items);
+      setTextCursor(result.textAnswers.nextCursor ?? null);
+      setTextTotal(result.textAnswers.totalCount);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '데이터를 불러오는 중 오류가 발생했습니다.';
+      setError(message);
+    } finally {
+      setInitialLoading(false);
+    }
+  }, [includeTestData, surveyId]);
+
+  const loadMoreResponses = useCallback(async () => {
+    if (!surveyId) return;
+    if (responsesLoading) return;
+    const cursor = responseCursor ?? null;
+    if (cursor === null) return;
+
+    setResponsesLoading(true);
+    setError(null);
+
+    try {
+      const result = await SurveyDetailRepository.fetchSurveyDetailStats({
+        surveyId,
+        includeTestData,
+        responseCursor: cursor,
+        responseLimit: SURVEY_DETAIL_DEFAULTS.responseLimit,
+        distributionLimit: 0,
+        textLimit: 0,
+      });
+
+      setSummary(result.summary);
+      setResponses((prev) => [...prev, ...result.responses.items]);
+      setResponseCursor(result.responses.nextCursor ?? null);
+      setResponseTotal(result.responses.totalCount);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '응답을 불러오는 중 오류가 발생했습니다.';
+      setError(message);
+    } finally {
+      setResponsesLoading(false);
+    }
+  }, [includeTestData, responseCursor, responsesLoading, surveyId]);
+
+  const loadMoreDistributions = useCallback(async () => {
+    if (!surveyId) return;
+    if (distributionsLoading) return;
+    const cursor = distributionCursor ?? null;
+    if (cursor === null) return;
+
+    setDistributionsLoading(true);
+    setError(null);
+
+    try {
+      const result = await SurveyDetailRepository.fetchSurveyDetailStats({
+        surveyId,
+        includeTestData,
+        distributionCursor: cursor,
+        distributionLimit: SURVEY_DETAIL_DEFAULTS.distributionLimit,
+        responseLimit: 0,
+        textLimit: 0,
+      });
+
+      setSummary(result.summary);
+      setDistributions((prev) => [...prev, ...result.distributions.items]);
+      setDistributionCursor(result.distributions.nextCursor ?? null);
+      setDistributionTotal(result.distributions.totalCount);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '질문 통계를 불러오는 중 오류가 발생했습니다.';
+      setError(message);
+    } finally {
+      setDistributionsLoading(false);
+    }
+  }, [distributionCursor, distributionsLoading, includeTestData, surveyId]);
+
+  const loadMoreTextAnswers = useCallback(async () => {
+    if (!surveyId) return;
+    if (textLoading) return;
+    const cursor = textCursor ?? null;
+    if (cursor === null) return;
+
+    setTextLoading(true);
+    setError(null);
+
+    try {
+      const result = await SurveyDetailRepository.fetchSurveyDetailStats({
+        surveyId,
+        includeTestData,
+        textCursor: cursor,
+        textLimit: SURVEY_DETAIL_DEFAULTS.textLimit,
+        responseLimit: 0,
+        distributionLimit: 0,
+      });
+
+      setSummary(result.summary);
+      setTextAnswers((prev) => [...prev, ...result.textAnswers.items]);
+      setTextCursor(result.textAnswers.nextCursor ?? null);
+      setTextTotal(result.textAnswers.totalCount);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '텍스트 응답을 불러오는 중 오류가 발생했습니다.';
+      setError(message);
+    } finally {
+      setTextLoading(false);
+    }
+  }, [includeTestData, surveyId, textCursor, textLoading]);
+
+  const refresh = useCallback(async () => {
+    resetState();
+    await fetchInitial();
+  }, [fetchInitial, resetState]);
+
+  useEffect(() => {
+    if (!autoFetch) return;
+    if (!surveyId) {
+      resetState();
+      return;
+    }
+
+    resetState();
+    fetchInitial();
+  }, [autoFetch, fetchInitial, includeTestData, resetState, surveyId]);
+
+  const groupedTextAnswers = useMemo<GroupedTextAnswers[]>(() => {
+    const map = new Map<string, GroupedTextAnswers>();
+
+    textAnswers.forEach((answer) => {
+      const existing = map.get(answer.questionId);
+      if (existing) {
+        existing.answers.push(answer);
+      } else {
+        map.set(answer.questionId, {
+          questionId: answer.questionId,
+          questionText: answer.questionText,
+          satisfactionType: answer.satisfactionType,
+          orderIndex: answer.orderIndex,
+          answers: [answer],
+        });
+      }
+    });
+
+    return Array.from(map.values()).sort((a, b) => {
+      if (a.orderIndex === null && b.orderIndex === null) {
+        return a.questionText.localeCompare(b.questionText);
+      }
+      if (a.orderIndex === null) return 1;
+      if (b.orderIndex === null) return -1;
+      return a.orderIndex - b.orderIndex;
+    });
+  }, [textAnswers]);
+
+  return {
+    summary,
+    responses,
+    responsesTotal: responseTotal,
+    hasMoreResponses: responseCursor !== null,
+    responsesLoading,
+    loadMoreResponses,
+    distributions,
+    distributionsTotal: distributionTotal,
+    hasMoreDistributions: distributionCursor !== null,
+    distributionsLoading,
+    loadMoreDistributions,
+    textAnswers,
+    groupedTextAnswers,
+    textAnswersTotal: textTotal,
+    hasMoreTextAnswers: textCursor !== null,
+    textAnswersLoading: textLoading,
+    loadMoreTextAnswers,
+    initialLoading,
+    error,
+    refresh,
+  };
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2433,6 +2433,30 @@ export type Database = {
           total_surveys: number
         }[]
       }
+      get_survey_detail_stats: {
+        Args: {
+          p_survey_id: string
+          p_include_test?: boolean | null
+          p_response_cursor?: number | null
+          p_response_limit?: number | null
+          p_distribution_cursor?: number | null
+          p_distribution_limit?: number | null
+          p_text_cursor?: number | null
+          p_text_limit?: number | null
+        }
+        Returns: {
+          distribution_next_cursor: number | null
+          distribution_total_count: number
+          question_distributions: Json
+          response_next_cursor: number | null
+          response_total_count: number
+          responses: Json
+          summary: Json
+          text_answers: Json
+          text_next_cursor: number | null
+          text_total_count: number
+        }[]
+      }
       get_session_statistics: {
         Args: { session_id_param?: string; survey_id_param?: string }
         Returns: {

--- a/src/pages/SurveyDetailedAnalysis.tsx
+++ b/src/pages/SurveyDetailedAnalysis.tsx
@@ -1,1131 +1,723 @@
-import { useState, useEffect } from 'react';
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { useAuth } from '@/hooks/useAuth';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import {
+  ResponsiveContainer,
+  BarChart as RechartsBarChart,
+  Bar,
+  CartesianGrid,
+  Tooltip,
+  XAxis,
+  YAxis,
+  PieChart,
+  Pie,
+  Cell,
+} from 'recharts';
+import { ArrowLeft, Download, Mail, Printer, Loader2 } from 'lucide-react';
+
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { ArrowLeft, Download, Printer, Mail, TrendingUp, Star, Users } from 'lucide-react';
-import { BarChart as RechartsBarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
 import { Progress } from '@/components/ui/progress';
-import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { TestDataToggle } from '@/components/TestDataToggle';
 import { useToast } from '@/hooks/use-toast';
+import { useTestDataToggle } from '@/hooks/useTestDataToggle';
+import { useSurveyDetailStats } from '@/hooks/useSurveyDetailStats';
+import type { SurveyQuestionDistribution } from '@/repositories/surveyDetailRepository';
 
 interface Survey {
   id: string;
   title: string;
   education_year: number;
   education_round: number;
-  education_day: number;
   status: string;
-  instructor_id: string;
-  course_name?: string;
-}
-
-interface SurveyResponse {
-  id: string;
-  survey_id: string;
-  session_id?: string | null;
-  submitted_at: string;
-  respondent_email: string;
-}
-
-interface QuestionAnswer {
-  id: string;
-  question_id: string;
-  response_id: string;
-  answer_text: string;
-  answer_value: any;
-  created_at: string;
-}
-
-interface SurveyQuestion {
-  id: string;
-  question_text: string;
-  question_type: string;
-  options: any;
-  is_required: boolean;
-  survey_id: string;
-  order_index: number;
-  satisfaction_type?: 'course' | 'subject' | 'instructor' | 'operation' | string;
-  session_id?: string | null;
-}
-
-interface CourseSession {
-  id: string;
-  title: string;
-  course_name: string;
-  session_name: string;
-  education_day: number;
-  instructor_name: string;
-  instructor_id: string;
-  instructor_email?: string;
-  status?: string;
+  course_name?: string | null;
+  instructor_id?: string | null;
 }
 
 interface Instructor {
   id: string;
   name: string;
   email: string;
-  photo_url: string;
+  photo_url?: string | null;
 }
 
-interface AnalysisComment {
-  id: string;
-  survey_id: string;
-  author_id: string;
-  content: string;
-  created_at: string;
-  updated_at: string;
+const RATING_QUESTION_TYPES = new Set(['rating', 'scale']);
+const SCORE_RANGE = Array.from({ length: 10 }, (_value, index) => index + 1);
+const CHART_COLORS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+];
+
+function formatAverage(value: number | null | undefined): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value.toFixed(1);
+  }
+  return '-';
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return '-';
+  try {
+    const date = new Date(value);
+    return new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  } catch {
+    return value;
+  }
 }
 
 const SurveyDetailedAnalysis = () => {
+  const { surveyId } = useParams<{ surveyId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const { surveyId } = useParams();
-  const { user, userRoles } = useAuth();
-  const [survey, setSurvey] = useState<Survey | null>(null);
-  const [instructor, setInstructor] = useState<Instructor | null>(null);
-  const [responses, setResponses] = useState<SurveyResponse[]>([]);
-  const [questions, setQuestions] = useState<SurveyQuestion[]>([]);
-  const [answers, setAnswers] = useState<QuestionAnswer[]>([]);
-  const [courseSessions, setCourseSessions] = useState<CourseSession[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [sendingResults, setSendingResults] = useState(false);
-  const [comments, setComments] = useState<AnalysisComment[]>([]);
-  const [commentText, setCommentText] = useState('');
-  const [savingComment, setSavingComment] = useState(false);
   const { toast } = useToast();
 
-  // Design system chart colors
-  const COLORS = [
-    'hsl(var(--chart-1))', // Purple
-    'hsl(var(--chart-2))', // Light purple
-    'hsl(var(--chart-3))', // Violet
-    'hsl(var(--chart-4))', // Blue purple
-    'hsl(var(--chart-5))'  // Pink purple
-  ];
+  const testDataOptions = useTestDataToggle();
+  const {
+    summary,
+    responses,
+    responsesTotal,
+    hasMoreResponses,
+    responsesLoading,
+    loadMoreResponses,
+    distributions,
+    distributionsTotal,
+    hasMoreDistributions,
+    distributionsLoading,
+    loadMoreDistributions,
+    groupedTextAnswers,
+    textAnswersTotal,
+    hasMoreTextAnswers,
+    textAnswersLoading,
+    loadMoreTextAnswers,
+    initialLoading,
+    error,
+    refresh,
+  } = useSurveyDetailStats({ surveyId, includeTestData: testDataOptions.includeTestData });
 
-  useEffect(() => {
-    if (surveyId) {
-      fetchSurveyData();
-      fetchResponses();
-      fetchQuestionsAndAnswers();  
-      fetchCourseSessions();
-      loadComments();
-    }
-  }, [surveyId]);
+  const [survey, setSurvey] = useState<Survey | null>(null);
+  const [instructor, setInstructor] = useState<Instructor | null>(null);
+  const [loadingSurvey, setLoadingSurvey] = useState(true);
+  const [sendingResults, setSendingResults] = useState(false);
 
-  const fetchSurveyData = async () => {
+  const loadSurvey = useCallback(async () => {
     if (!surveyId) return;
-    
+
+    setLoadingSurvey(true);
     try {
       const { data: surveyData, error: surveyError } = await supabase
         .from('surveys')
-        .select('*')
+        .select('id, title, education_year, education_round, status, course_name, instructor_id')
         .eq('id', surveyId)
         .single();
-      
-      if (surveyError) throw surveyError;
-      setSurvey(surveyData);
 
-      // 강사 정보 가져오기
-      if (surveyData.instructor_id) {
+      if (surveyError) throw surveyError;
+      setSurvey(surveyData as Survey);
+
+      if (surveyData?.instructor_id) {
         const { data: instructorData, error: instructorError } = await supabase
           .from('instructors')
-          .select('*')
+          .select('id, name, email, photo_url')
           .eq('id', surveyData.instructor_id)
           .single();
-        
+
         if (instructorError) throw instructorError;
-        setInstructor(instructorData);
+        setInstructor(instructorData as Instructor);
+      } else {
+        setInstructor(null);
       }
-    } catch (error) {
-      console.error('Error fetching survey data:', error);
+    } catch (err) {
+      console.error('Error loading survey:', err);
+      setSurvey(null);
     } finally {
-      setLoading(false);
+      setLoadingSurvey(false);
     }
-  };
+  }, [surveyId]);
 
-  const fetchResponses = async () => {
+  useEffect(() => {
+    loadSurvey();
+  }, [loadSurvey]);
+
+  const handleSendResults = useCallback(async () => {
     if (!surveyId) return;
-    
-    try {
-      const { data, error } = await supabase
-        .from('survey_responses')
-        .select('id, survey_id, session_id, submitted_at, respondent_email')
-        .eq('survey_id', surveyId)
-        .order('submitted_at', { ascending: false });
-      
-      if (error) throw error;
-      setResponses(data || []);
-    } catch (error) {
-      console.error('Error fetching responses:', error);
-    }
-  };
 
-  const fetchQuestionsAndAnswers = async () => {
-    if (!surveyId) return;
-    
-    try {
-      // 설문 질문들 가져오기
-      const { data: questionsData, error: questionsError } = await supabase
-        .from('survey_questions')
-        .select('*')
-        .eq('survey_id', surveyId)
-        .order('order_index');
-      
-      if (questionsError) throw questionsError;
-      setQuestions(questionsData || []);
-
-      // 해당 설문의 모든 응답 ID들 가져오기
-      const { data: responseIds, error: responseError } = await supabase
-        .from('survey_responses')
-        .select('id')
-        .eq('survey_id', surveyId);
-      
-      if (responseError) throw responseError;
-      
-      if (responseIds && responseIds.length > 0) {
-        const ids = responseIds.map(r => r.id);
-        
-        // 답변들 가져오기
-        const { data: answersData, error: answersError } = await supabase
-          .from('question_answers')
-          .select('*')
-          .in('response_id', ids)
-          .order('created_at');
-        
-        if (answersError) throw answersError;
-        setAnswers(answersData || []);
-      } else {
-        setAnswers([]);
-      }
-    } catch (error) {
-      console.error('Error fetching questions and answers:', error);
-    }
-  };
-
-  const fetchCourseSessions = async () => {
-    if (!surveyId) return;
-    
-    try {
-      // 현재 설문에서 세션들을 가져오기
-      const { data: sessions, error } = await supabase
-        .from('survey_sessions')
-        .select(`
-          id,
-          session_name,
-          session_order,
-          survey_id,
-          course_id,
-          instructor_id,
-          courses (
-            id,
-            title
-          ),
-          instructors (
-            id,
-            name,
-            email
-          )
-        `)
-        .eq('survey_id', surveyId)
-        .order('session_order');
-      
-      if (error) throw error;
-      
-      // 강사 권한 체크 및 필터링
-      let filteredSessions = sessions || [];
-      if (userRoles.includes('instructor')) {
-        // 현재 로그인한 사용자의 강사 ID 찾기
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('instructor_id')
-          .eq('id', user?.id)
-          .single();
-          
-        if (profile?.instructor_id) {
-          filteredSessions = sessions?.filter((s: any) => s.instructor_id === profile.instructor_id) || [];
-        }
-      }
-
-      // 세션 정보 구성
-      const courseSessions = filteredSessions.map((session: any) => ({
-        id: session.id,
-        title: session.courses?.title || session.session_name || '과목명 없음',
-        course_name: session.courses?.title || session.session_name || '',
-        session_name: session.session_name || session.courses?.title || '과목명 없음',
-        education_day: 1, // survey_sessions 테이블에는 education_day가 없으므로 기본값
-        instructor_name: session.instructors?.name || '강사 정보 없음',
-        instructor_id: session.instructor_id,
-        instructor_email: session.instructors?.email || '',
-        status: 'active' // survey_sessions 테이블에는 status가 없으므로 기본값
-      }));
-      
-      console.log('Fetched course sessions:', courseSessions);
-      setCourseSessions(courseSessions);
-    } catch (error) {
-      console.error('Error fetching course sessions:', error);
-      setCourseSessions([]);
-    }
-  };
-
-  const loadComments = async () => {
-    if (!surveyId) return;
-    
-    try {
-      const { data, error } = await supabase
-        .from('survey_analysis_comments')
-        .select(`
-          *,
-          profiles (
-            email
-          )
-        `)
-        .eq('survey_id', surveyId)
-        .order('created_at', { ascending: false });
-      
-      if (error) throw error;
-      setComments(data || []);
-    } catch (error) {
-      console.error('Error loading comments:', error);
-    }
-  };
-
-  const getSubjectAnalysis = (sessionId: string) => {
-    // 선택된 세션에 따라 질문들을 필터링하고 분석
-    let filteredQuestions = questions;
-    let filteredAnswers = answers;
-    let filteredResponses = responses;
-
-    if (sessionId !== 'all') {
-      // 선택된 세션 정보 가져오기
-      const selectedSession = courseSessions.find(cs => cs.id === sessionId);
-
-      if (selectedSession) {
-        const sessionQuestions = questions.filter(q => q.session_id === sessionId);
-        const sessionQuestionIdSet = new Set(sessionQuestions.map(q => q.id));
-
-        // 세션 문항에 답변한 응답 ID만 추출
-        const sessionResponseIdSet = new Set(
-          answers
-            .filter(a => sessionQuestionIdSet.has(a.question_id))
-            .map(a => a.response_id)
-        );
-
-        // 응답 자체에 세션 정보가 있는 경우 함께 포함
-        responses.forEach(response => {
-          if (response.session_id === sessionId) {
-            sessionResponseIdSet.add(response.id);
-          }
-        });
-
-        // 공통 문항은 해당 세션에 응답이 존재할 때만 포함
-        const sharedQuestions = sessionResponseIdSet.size > 0
-          ? questions.filter(q => !q.session_id)
-          : [];
-
-        const uniqueQuestionMap = new Map<string, SurveyQuestion>();
-        [...sessionQuestions, ...sharedQuestions].forEach(q => {
-          uniqueQuestionMap.set(q.id, q);
-        });
-
-        filteredQuestions = Array.from(uniqueQuestionMap.values());
-
-        const allowedQuestionIds = new Set(filteredQuestions.map(q => q.id));
-
-        filteredAnswers = answers.filter(a => {
-          if (!allowedQuestionIds.has(a.question_id)) {
-            return false;
-          }
-          if (sessionResponseIdSet.size > 0) {
-            return sessionResponseIdSet.has(a.response_id);
-          }
-          return true;
-        });
-
-        filteredResponses = responses.filter(r => sessionResponseIdSet.has(r.id));
-      } else {
-        // 세션을 찾을 수 없는 경우 빈 배열로 설정
-        filteredQuestions = [];
-        filteredAnswers = [];
-        filteredResponses = [];
-      }
-    }
-
-    const subjectQuestions: SurveyQuestion[] = [];
-    const instructorQuestions: SurveyQuestion[] = [];
-    const operationQuestions: SurveyQuestion[] = [];
-
-    filteredQuestions.forEach((question) => {
-      const type = (question as any).satisfaction_type as string | undefined;
-      if (type === 'instructor') {
-        instructorQuestions.push(question);
-      } else if (type === 'operation') {
-        operationQuestions.push(question);
-      } else if (type === 'course' || type === 'subject') {
-        subjectQuestions.push(question);
-      } else {
-        // 타입 정보가 없을 때: 평점형은 과목으로, 나머지는 과목 기본
-        if (question.question_type === 'rating' || question.question_type === 'scale') {
-          subjectQuestions.push(question);
-        } else {
-          subjectQuestions.push(question);
-        }
-      }
-    });
-
-    // 필터링된 답변을 사용하여 분석
-    const getFilteredQuestionAnalysis = (questions: SurveyQuestion[]) => {
-      return questions.map(question => {
-        const questionAnswers = filteredAnswers.filter(a => a.question_id === question.id);
-        
-        if (question.question_type === 'multiple_choice' || question.question_type === 'single_choice') {
-          const answerCounts: Record<string, number> = {};
-          questionAnswers.forEach(answer => {
-            const answerText = answer.answer_text;
-            answerCounts[answerText] = (answerCounts[answerText] || 0) + 1;
-          });
-
-          return {
-            question,
-            type: 'chart' as const,
-            totalAnswers: questionAnswers.length,
-            chartData: Object.entries(answerCounts).map(([answer, count]) => ({
-              name: answer,
-              value: count,
-              percentage: questionAnswers.length > 0 ? Math.round((count / questionAnswers.length) * 100) : 0
-            }))
-          };
-        } else if (question.question_type === 'rating' || question.question_type === 'scale') {
-          const ratings = questionAnswers.map(a => parseInt(a.answer_text)).filter(r => !isNaN(r));
-          const maxScore = Math.max(...ratings, 0);
-          let convertedRatings = ratings;
-          
-          if (maxScore <= 5 && maxScore > 0) {
-            convertedRatings = ratings.map(r => r * 2);
-          }
-          
-          const average = convertedRatings.length > 0 ? (convertedRatings.reduce((sum, r) => sum + r, 0) / convertedRatings.length).toFixed(1) : '0';
-          
-          const distribution = {};
-          for (let i = 1; i <= 10; i++) {
-            distribution[i] = convertedRatings.filter(r => r === i).length;
-          }
-          
-          return {
-            question,
-            type: 'rating' as const,
-            totalAnswers: questionAnswers.length,
-            average,
-            chartData: Object.entries(distribution).map(([score, count]) => ({
-              name: `${score}점`,
-              value: count as number,
-              percentage: convertedRatings.length > 0 ? Math.round(((count as number) / convertedRatings.length) * 100) : 0
-            }))
-          };
-        } else {
-          return {
-            question,
-            type: 'text' as const,
-            totalAnswers: questionAnswers.length,
-            answers: questionAnswers.slice(0, 10)
-          };
-        }
-      });
-    };
-
-    // 카테고리별 평균 계산 함수
-    const calculateCategoryAverage = (questionList: SurveyQuestion[]) => {
-      const ratingQuestions = questionList.filter(q => q.question_type === 'rating' || q.question_type === 'scale');
-      if (ratingQuestions.length === 0) return '0';
-
-      let totalScore = 0;
-      let totalCount = 0;
-
-      ratingQuestions.forEach(question => {
-        const questionAnswers = filteredAnswers.filter(a => a.question_id === question.id);
-        const ratings = questionAnswers.map(a => parseInt(a.answer_text)).filter(r => !isNaN(r));
-        
-        if (ratings.length > 0) {
-          const maxScore = Math.max(...ratings);
-          let convertedRatings = ratings;
-          
-          if (maxScore <= 5) {
-            convertedRatings = ratings.map(r => r * 2);
-          }
-          
-          totalScore += convertedRatings.reduce((sum, r) => sum + r, 0);
-          totalCount += convertedRatings.length;
-        }
-      });
-
-      return totalCount > 0 ? (totalScore / totalCount).toFixed(1) : '0';
-    };
-
-    return {
-      subjectQuestions,
-      instructorQuestions,
-      operationQuestions,
-      filteredQuestions,
-      filteredAnswers,
-      filteredResponses,
-      getFilteredQuestionAnalysis,
-      calculateCategoryAverage
-    };
-  };
-
-  const categorizeQuestions = () => {
-    const subjectQuestions: SurveyQuestion[] = [];
-    const instructorQuestions: SurveyQuestion[] = [];
-    const operationQuestions: SurveyQuestion[] = [];
-
-    questions.forEach((question) => {
-      const type = (question as any).satisfaction_type as string | undefined;
-
-      if (type === 'instructor') {
-        instructorQuestions.push(question);
-      } else if (type === 'operation') {
-        operationQuestions.push(question);
-      } else if (type === 'course' || type === 'subject') {
-        subjectQuestions.push(question);
-      } else {
-        // 타입 정보가 없을 때의 안전한 기본값: 평점형은 과목으로 분류
-        if (question.question_type === 'rating' || question.question_type === 'scale') {
-          subjectQuestions.push(question);
-        } else {
-          subjectQuestions.push(question);
-        }
-      }
-    });
-
-    return { subjectQuestions, instructorQuestions, operationQuestions };
-  };
-
-  const getQuestionAnalysis = (questionList: SurveyQuestion[]) => {
-    // order_index 순서로 정렬
-    const sortedQuestions = [...questionList].sort((a, b) => a.order_index - b.order_index);
-    return sortedQuestions.map(question => {
-      const questionAnswers = answers.filter(a => a.question_id === question.id);
-      
-      if (question.question_type === 'multiple_choice' || question.question_type === 'single_choice') {
-        const options = question.options || [];
-        const answerCounts = {};
-        
-        options.forEach(option => {
-          answerCounts[option] = 0;
-        });
-        
-        questionAnswers.forEach(answer => {
-          if (answer.answer_text && answerCounts.hasOwnProperty(answer.answer_text)) {
-            answerCounts[answer.answer_text]++;
-          }
-        });
-        
-        const chartData = Object.entries(answerCounts).map(([option, count]) => ({
-          name: option,
-          value: count as number,
-          percentage: questionAnswers.length > 0 ? Math.round(((count as number) / questionAnswers.length) * 100) : 0
-        }));
-        
-        return {
-          question,
-          totalAnswers: questionAnswers.length,
-          chartData,
-          type: 'chart'
-        };
-      } else if (question.question_type === 'rating' || question.question_type === 'scale') {
-        const ratings = questionAnswers.map(a => parseInt(a.answer_text)).filter(r => !isNaN(r));
-        // 원본 점수가 이미 10점 척도인지 5점 척도인지 확인
-        const maxScore = Math.max(...ratings);
-        let convertedRatings = ratings;
-        
-        // 5점 척도라면 10점 척도로 변환
-        if (maxScore <= 5) {
-          convertedRatings = ratings.map(r => r * 2);
-        }
-        
-        const average = convertedRatings.length > 0 ? (convertedRatings.reduce((sum, r) => sum + r, 0) / convertedRatings.length).toFixed(1) : '0';
-        
-        // 점수별 분포 계산 (10점 만점 기준)
-        const distribution = {};
-        for (let i = 1; i <= 10; i++) {
-          distribution[i] = convertedRatings.filter(r => r === i).length;
-        }
-        
-        const chartData = Object.entries(distribution).map(([score, count]) => ({
-          name: `${score}점`,
-          value: count as number,
-          percentage: convertedRatings.length > 0 ? Math.round(((count as number) / convertedRatings.length) * 100) : 0
-        }));
-        
-        return {
-          question,
-          totalAnswers: questionAnswers.length,
-          average,
-          chartData,
-          type: 'rating'
-        };
-      } else {
-        // 텍스트 답변
-        return {
-          question,
-          totalAnswers: questionAnswers.length,
-          answers: questionAnswers.slice(0, 10), // 최대 10개만 표시
-          type: 'text'
-        };
-      }
-    });
-  };
-
-  const calculateCategoryAverage = (questionList: SurveyQuestion[]) => {
-    const ratingQuestions = questionList.filter(q => q.question_type === 'rating' || q.question_type === 'scale');
-    if (ratingQuestions.length === 0) return 0;
-
-    let totalScore = 0;
-    let totalCount = 0;
-
-    ratingQuestions.forEach(question => {
-      const questionAnswers = answers.filter(a => a.question_id === question.id);
-      const ratings = questionAnswers.map(a => parseInt(a.answer_text)).filter(r => !isNaN(r));
-      
-      if (ratings.length > 0) {
-        // 원본 점수가 이미 10점 척도인지 5점 척도인지 확인
-        const maxScore = Math.max(...ratings);
-        let convertedRatings = ratings;
-        
-        // 5점 척도라면 10점 척도로 변환
-        if (maxScore <= 5) {
-          convertedRatings = ratings.map(r => r * 2);
-        }
-        
-        totalScore += convertedRatings.reduce((sum, r) => sum + r, 0);
-        totalCount += convertedRatings.length;
-      }
-    });
-
-    return totalCount > 0 ? (totalScore / totalCount).toFixed(1) : '0';
-  };
-
-  const calculateOverallSatisfaction = () => {
-    const { subjectQuestions, instructorQuestions, operationQuestions } = categorizeQuestions();
-    const allRatingQuestions = [...subjectQuestions, ...instructorQuestions, ...operationQuestions]
-      .filter(q => q.question_type === 'rating' || q.question_type === 'scale');
-    
-    if (allRatingQuestions.length === 0) return '0';
-
-    let totalScore = 0;
-    let totalCount = 0;
-
-    allRatingQuestions.forEach(question => {
-      const questionAnswers = answers.filter(a => a.question_id === question.id);
-      const ratings = questionAnswers.map(a => parseInt(a.answer_text)).filter(r => !isNaN(r));
-      
-      if (ratings.length > 0) {
-        const maxScore = Math.max(...ratings);
-        let convertedRatings = ratings;
-        
-        if (maxScore <= 5) {
-          convertedRatings = ratings.map(r => r * 2);
-        }
-        
-        totalScore += convertedRatings.reduce((sum, r) => sum + r, 0);
-        totalCount += convertedRatings.length;
-      }
-    });
-
-    return totalCount > 0 ? (totalScore / totalCount).toFixed(1) : '0';
-  };
-
-  const handleSendResults = async () => {
-    if (!surveyId) return;
-    
     setSendingResults(true);
     try {
-      const { error } = await supabase.functions.invoke('send-survey-results', {
-        body: { surveyId }
+      const { error: sendError } = await supabase.functions.invoke('send-survey-results', {
+        body: { surveyId },
       });
-      
-      if (error) throw error;
-      
+
+      if (sendError) throw sendError;
+
       toast({
-        title: "전송 완료",
-        description: "설문 결과가 이메일로 전송되었습니다.",
+        title: '전송 완료',
+        description: '설문 결과가 이메일로 전송되었습니다.',
       });
-    } catch (error) {
-      console.error('Error sending results:', error);
+    } catch (err) {
+      console.error('Error sending results:', err);
       toast({
-        title: "전송 실패",
-        description: "결과 전송 중 오류가 발생했습니다.",
-        variant: "destructive",
+        title: '전송 실패',
+        description: '결과 전송 중 오류가 발생했습니다.',
+        variant: 'destructive',
       });
     } finally {
       setSendingResults(false);
     }
-  };
+  }, [surveyId, toast]);
 
-  const handleDownload = () => {
+  const generateCSV = useCallback(() => {
+    if (!survey || !summary) return '';
+
+    let csv = '설문 상세 분석 결과\n';
+    csv += `설문명: ${survey.title}\n`;
+    csv += `교육년도: ${survey.education_year}년\n`;
+    csv += `교육차수: ${survey.education_round}차\n`;
+    csv += `총 응답 수: ${summary.responseCount}\n\n`;
+
+    csv += `종합 만족도,${formatAverage(summary.avgOverall)}/10\n`;
+    csv += `과목 만족도,${formatAverage(summary.avgCourse)}/10\n`;
+    csv += `강사 만족도,${formatAverage(summary.avgInstructor)}/10\n`;
+    csv += `운영 만족도,${formatAverage(summary.avgOperation)}/10\n\n`;
+
+    csv += '질문,질문유형,응답수,분석결과\n';
+    distributions.forEach((distribution) => {
+      const escapedQuestion = distribution.questionText.replace(/"/g, '""');
+      const base = `"${escapedQuestion}",${distribution.questionType},${distribution.totalAnswers},`;
+
+      if (RATING_QUESTION_TYPES.has(distribution.questionType)) {
+        csv += `${base}"평균: ${formatAverage(distribution.average)}/10"\n`;
+      } else if (distribution.optionCounts.length > 0) {
+        const top = distribution.optionCounts.reduce(
+          (best, option) => (option.count > best.count ? option : best),
+          { option: '', count: 0 },
+        );
+        csv += `${base}"최다 응답: ${top.option} (${top.count}명)"\n`;
+      } else {
+        const group = groupedTextAnswers.find((item) => item.questionId === distribution.questionId);
+        const count = group ? group.answers.length : 0;
+        csv += `${base}"텍스트 응답 ${count}개"\n`;
+      }
+    });
+
+    if (groupedTextAnswers.length > 0) {
+      csv += '\n텍스트 응답 요약\n';
+      groupedTextAnswers.forEach((group) => {
+        const escapedQuestion = group.questionText.replace(/"/g, '""');
+        const preview = group.answers
+          .slice(0, 5)
+          .map((answer) => answer.answerText.replace(/"/g, '""'))
+          .join('; ');
+        csv += `"${escapedQuestion}",text,${group.answers.length},"${preview}"\n`;
+      });
+    }
+
+    return csv;
+  }, [distributions, groupedTextAnswers, summary, survey]);
+
+  const handleDownload = useCallback(() => {
     const csv = generateCSV();
+    if (!csv) return;
+
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
-    const url = URL.createObjectURL(blob);
-    link.setAttribute('href', url);
-    link.setAttribute('download', `survey_analysis_${survey?.title || 'results'}.csv`);
+    link.href = URL.createObjectURL(blob);
+    link.download = `survey_analysis_${survey?.title || 'results'}.csv`;
     link.style.visibility = 'hidden';
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-  };
+  }, [generateCSV, survey?.title]);
 
-  const generateCSV = () => {
-    if (!survey) return '';
-    
-    let csvContent = '설문 상세 분석 결과\n';
-    csvContent += `설문명: ${survey.title}\n`;
-    csvContent += `교육년도: ${survey.education_year}년\n`;
-    csvContent += `교육차수: ${survey.education_round}차\n`;
-    csvContent += `총 응답 수: ${responses.length}\n\n`;
-    
-    // 종합 만족도
-    csvContent += `종합 만족도: ${calculateOverallSatisfaction()}/10\n`;
-    
-    // 과목 만족도 통계
-    const subjectAvg = calculateCategoryAverage(categorizeQuestions().subjectQuestions);
-    const subjectAvgStr = String(subjectAvg);
-    csvContent += `과목 만족도,${subjectAvgStr !== '0' ? subjectAvgStr : '-'}/10\n`;
-    
-    // 강사 만족도 통계
-    const instructorAvg = calculateCategoryAverage(categorizeQuestions().instructorQuestions);
-    const instructorAvgStr = String(instructorAvg);
-    csvContent += `강사 만족도,${instructorAvgStr !== '0' ? instructorAvgStr : '-'}/10\n`;
-    
-    // 운영 만족도 통계
-    const operationAvg = calculateCategoryAverage(categorizeQuestions().operationQuestions);
-    const operationAvgStr = String(operationAvg);
-    csvContent += `운영 만족도,${operationAvgStr !== '0' ? operationAvgStr : '-'}/10\n\n`;
-    
-    // 질문별 분석
-    csvContent += `질문,질문유형,응답수,분석결과\n`;
-    
-    const { subjectQuestions, instructorQuestions, operationQuestions } = categorizeQuestions();
-    
-    [...subjectQuestions, ...instructorQuestions, ...operationQuestions].forEach((question, index) => {
-      const analysis = getQuestionAnalysis([question])[0];
-      csvContent += `"${question.question_text}",${question.question_type},${analysis.totalAnswers},"`;
-      
-      if (analysis.type === 'rating') {
-        csvContent += `평균: ${analysis.average}점`;
-      } else if (analysis.type === 'chart') {
-        const topAnswer = analysis.chartData.reduce((a, b) => a.value > b.value ? a : b, {name: '', value: 0});
-        csvContent += `최다응답: ${topAnswer.name} (${topAnswer.value}명)`;
-      } else {
-        csvContent += `텍스트 응답 ${analysis.totalAnswers}개`;
-      }
-      
-      csvContent += `"\n`;
-    });
-    
-    return csvContent;
-  };
+  const ratingDistributions = useMemo(
+    () => distributions.filter((item) => RATING_QUESTION_TYPES.has(item.questionType)),
+    [distributions],
+  );
 
-  if (loading) {
+  const choiceDistributions = useMemo(
+    () =>
+      distributions.filter(
+        (item) => !RATING_QUESTION_TYPES.has(item.questionType) && item.optionCounts.length > 0,
+      ),
+    [distributions],
+  );
+
+  const otherQuestions = useMemo(
+    () =>
+      distributions.filter(
+        (item) => !RATING_QUESTION_TYPES.has(item.questionType) && item.optionCounts.length === 0,
+      ),
+    [distributions],
+  );
+
+  if (!surveyId) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div>로딩중...</div>
+      <div className="flex items-center justify-center py-12">
+        <p className="text-muted-foreground">유효한 설문 ID가 제공되지 않았습니다.</p>
+      </div>
+    );
+  }
+
+  if (loadingSurvey) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
       </div>
     );
   }
 
   if (!survey) {
     return (
-      <div className="flex items-center justify-center py-8">
-        <div>설문을 찾을 수 없습니다.</div>
+      <div className="flex items-center justify-center py-12">
+        <p className="text-muted-foreground">설문을 찾을 수 없습니다.</p>
       </div>
     );
   }
 
-  const { subjectQuestions, instructorQuestions, operationQuestions } = categorizeQuestions();
-  const subjectAnalysis = getQuestionAnalysis([...subjectQuestions, ...instructorQuestions, ...operationQuestions]);
+  const handleNavigateBack = () => {
+    const from = (location.state as { from?: string } | undefined)?.from;
+    if (from === 'survey-management') {
+      navigate('/surveys-v2');
+    } else {
+      navigate('/dashboard/results');
+    }
+  };
+
+  const renderSummaryCard = (title: string, value: string) => (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {value !== '-' && (
+          <Progress value={Number(value) * 10} className="mt-2" />
+        )}
+      </CardContent>
+    </Card>
+  );
+
+  const renderRatingChart = (distribution: SurveyQuestionDistribution) => {
+    const values = distribution.ratingDistribution;
+    const total = SCORE_RANGE.reduce((acc, score) => acc + (values[score] ?? 0), 0);
+    const chartData = SCORE_RANGE.map((score) => ({
+      name: `${score}점`,
+      value: values[score] ?? 0,
+      percentage: total > 0 ? Math.round(((values[score] ?? 0) / total) * 100) : 0,
+    }));
+
+    return (
+      <div className="w-full">
+        <ResponsiveContainer width="100%" height={200}>
+          <RechartsBarChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis allowDecimals={false} />
+            <Tooltip
+              formatter={(value: number | string, _name, props) => {
+                const percentage = props?.payload?.percentage ?? 0;
+                return [`${value}개 (${percentage}%)`, '응답 수'];
+              }}
+            />
+            <Bar dataKey="value" fill="hsl(var(--chart-1))" />
+          </RechartsBarChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  };
+
+  const renderChoiceChart = (distribution: SurveyQuestionDistribution) => {
+    const total = distribution.optionCounts.reduce((acc, item) => acc + item.count, 0);
+    const chartData = distribution.optionCounts.map((item) => ({
+      name: item.option,
+      value: item.count,
+      percentage: total > 0 ? Math.round((item.count / total) * 100) : 0,
+    }));
+
+    return (
+      <div className="w-full">
+        <ResponsiveContainer width="100%" height={320}>
+          <PieChart>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="50%"
+              labelLine={false}
+              label={({ name, percentage }) => `${name} (${percentage}%)`}
+              outerRadius={100}
+              dataKey="value"
+            >
+              {chartData.map((_entry, index) => (
+                <Cell key={index} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip formatter={(value, name) => [`${value}개`, name]} />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  };
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
       <header className="border-b bg-white/95 backdrop-blur-sm sticky top-0 z-50 shadow-sm">
-        <div className="container mx-auto px-4 py-3 flex items-center relative">
-          <Button
-            onClick={() => {
-              const from = location.state?.from;
-              if (from === 'survey-management') {
-                navigate('/surveys-v2');
-              } else {
-                navigate('/dashboard/results');
-              }
-            }}
-            variant="ghost"
-            size="sm"
-            className="touch-friendly"
-          >
+        <div className="container mx-auto flex items-center justify-between px-4 py-3">
+          <Button onClick={handleNavigateBack} variant="ghost" size="sm" className="touch-friendly">
             <ArrowLeft className="h-4 w-4" />
-            <span className="hidden sm:inline ml-1">
-              {location.state?.from === 'survey-management' ? '설문 관리' : '결과 분석'}
-            </span>
+            <span className="ml-1 hidden sm:inline">뒤로가기</span>
           </Button>
-          <div className="absolute left-1/2 transform -translate-x-1/2">
-            <h1 className="text-sm sm:text-lg font-semibold text-primary text-center break-words">상세 분석</h1>
-            <p className="text-xs text-muted-foreground break-words text-center line-clamp-2">
-              {survey.title}
-            </p>
+          <div className="text-center">
+            <h1 className="text-sm font-semibold text-primary sm:text-lg">상세 분석</h1>
+            <p className="line-clamp-2 text-xs text-muted-foreground sm:text-sm">{survey.title}</p>
           </div>
+          <div className="w-16" aria-hidden />
         </div>
       </header>
 
-      <main className="container mx-auto px-4 py-6">
-        <div className="space-y-6">
-          {/* 설문 정보 */}
-          <Card>
-            <CardHeader>
-              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
-                <div>
-                  <CardTitle className="break-words">{survey.title}</CardTitle>
-                  <div className="flex items-center gap-2 mt-2">
-                    <Badge variant={survey.status === 'active' ? 'default' : 'secondary'}>
-                      {survey.status === 'active' ? '진행중' : survey.status === 'completed' ? '완료' : '초안'}
-                    </Badge>
-                    <span className="text-sm text-muted-foreground">
-                      {survey.education_year}년 {survey.education_round}차
+      <main className="container mx-auto space-y-6 px-4 py-6">
+        {testDataOptions.canToggleTestData && (
+          <div className="flex justify-end">
+            <TestDataToggle testDataOptions={testDataOptions} />
+          </div>
+        )}
+
+        <Card>
+          <CardHeader>
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <CardTitle className="break-words text-xl">{survey.title}</CardTitle>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Badge variant={survey.status === 'active' ? 'default' : 'secondary'}>
+                    {survey.status === 'active' ? '진행중' : survey.status === 'completed' ? '완료' : '초안'}
+                  </Badge>
+                  <span>
+                    {survey.education_year}년 {survey.education_round}차
+                  </span>
+                  {survey.course_name && <span>{survey.course_name}</span>}
+                </div>
+                {instructor && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    {instructor.photo_url && (
+                      <img
+                        src={instructor.photo_url}
+                        alt={instructor.name}
+                        className="h-8 w-8 rounded-full object-cover"
+                      />
+                    )}
+                    <span>
+                      강사: {instructor.name}
+                      {instructor.email ? ` (${instructor.email})` : ''}
                     </span>
                   </div>
-                  {instructor && (
-                    <div className="flex items-center gap-2 mt-2">
-                      {instructor.photo_url && (
-                        <img 
-                          src={instructor.photo_url} 
-                          alt={instructor.name}
-                          className="w-6 h-6 rounded-full object-cover"
-                        />
-                      )}
-                      <span className="text-sm text-muted-foreground">
-                        강사: {instructor.name} ({instructor.email})
-                      </span>
-                    </div>
-                  )}
+                )}
+              </div>
+              <div className="text-right">
+                <div className="text-2xl font-bold text-primary">
+                  {summary ? summary.responseCount : '-'}
                 </div>
-                <div className="text-right">
-                  <div className="text-2xl font-bold text-primary">{responses.length}</div>
-                  <div className="text-sm text-muted-foreground">총 응답</div>
-                </div>
+                <div className="text-sm text-muted-foreground">총 응답</div>
               </div>
-            </CardHeader>
-          </Card>
+            </div>
+          </CardHeader>
+        </Card>
 
-          {/* 액션 버튼들 */}
-          <div className="flex gap-2 flex-wrap">
-            <Button 
-              variant="default" 
-              size="sm" 
-              onClick={handleSendResults}
-              disabled={sendingResults}
-            >
-              <Mail className="h-4 w-4 mr-2" />
-              {sendingResults ? '전송 중...' : '결과 전송'}
-            </Button>
-            <Button 
-              variant="outline" 
-              size="sm"
-              onClick={handleDownload}
-            >
-              <Download className="h-4 w-4 mr-2" />
-              엑셀 다운로드
-            </Button>
-            <Button variant="outline" size="sm" onClick={() => window.print()}>
-              <Printer className="h-4 w-4 mr-2" />
-              인쇄
-            </Button>
-          </div>
-
-          {/* 과목-강사별 탭 */}
-          <Tabs defaultValue="all" className="w-full">
-            <TabsList className="grid w-full" style={{ gridTemplateColumns: `repeat(${Math.min(courseSessions.length + 1, 6)}, 1fr)` }}>
-              <TabsTrigger value="all">전체</TabsTrigger>
-              {courseSessions.map((session) => (
-                <TabsTrigger key={session.id} value={session.id} className="text-xs">
-                  {session.session_name}
-                  {session.instructor_name && (
-                    <div className="text-[10px] text-muted-foreground mt-0.5">
-                      {session.instructor_name}
-                    </div>
-                  )}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-
-            <TabsContent value="all" className="space-y-6">
-              <div className="grid gap-6 md:grid-cols-3">
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">종합 만족도</CardTitle>
-                    <Star className="h-4 w-4 text-muted-foreground" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{calculateOverallSatisfaction()}/10</div>
-                    <Progress value={parseFloat(calculateOverallSatisfaction()) * 10} className="mt-2" />
-                  </CardContent>
-                </Card>
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">과목 만족도</CardTitle>
-                    <TrendingUp className="h-4 w-4 text-muted-foreground" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{calculateCategoryAverage(subjectQuestions)}/10</div>
-                    <Progress value={parseFloat(String(calculateCategoryAverage(subjectQuestions))) * 10} className="mt-2" />
-                  </CardContent>
-                </Card>
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">강사 만족도</CardTitle>
-                    <TrendingUp className="h-4 w-4 text-muted-foreground" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{calculateCategoryAverage(instructorQuestions)}/10</div>
-                    <Progress value={parseFloat(String(calculateCategoryAverage(instructorQuestions))) * 10} className="mt-2" />
-                  </CardContent>
-                </Card>
-              </div>
-
-              {/* 전체 문항 분석 */}
-              <div className="space-y-6">
-                {subjectAnalysis.map((analysis, index) => (
-                  <Card key={index}>
-                    <CardHeader>
-                      <CardTitle className="text-base">{analysis.question.question_text}</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                      {analysis.type === 'rating' && (
-                        <div className="space-y-4">
-                          <div className="flex items-center gap-4">
-                            <div className="text-3xl font-bold text-primary">{analysis.average}/10</div>
-                            <div className="text-sm text-muted-foreground">
-                              총 {analysis.totalAnswers}개 응답
-                            </div>
-                          </div>
-                          <div className="w-full">
-                            <ResponsiveContainer width="100%" height={200}>
-                              <RechartsBarChart data={analysis.chartData}>
-                                <CartesianGrid strokeDasharray="3 3" />
-                                <XAxis dataKey="name" />
-                                <YAxis />
-                                <Tooltip
-                                  formatter={(value: number | string, _name: string, props: any) => {
-                                    const percentage = props?.payload?.percentage ?? 0;
-                                    return [`${value}개 (${percentage}%)`, '응답 수'];
-                                  }}
-                                />
-                                <Bar dataKey="value" fill="hsl(var(--chart-1))" />
-                              </RechartsBarChart>
-                            </ResponsiveContainer>
-                          </div>
-                        </div>
-                      )}
-                      {analysis.type === 'chart' && (
-                        <div className="w-full">
-                          <ResponsiveContainer width="100%" height={300}>
-                            <PieChart>
-                              <Pie
-                                data={analysis.chartData}
-                                cx="50%"
-                                cy="50%"
-                                labelLine={false}
-                                label={({ name, percentage }) => `${name} (${percentage}%)`}
-                                outerRadius={80}
-                                fill="hsl(var(--chart-1))"
-                                dataKey="value"
-                              >
-                                {analysis.chartData.map((entry, index) => (
-                                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                ))}
-                              </Pie>
-                              <Tooltip formatter={(value, name) => [`${value}개`, name]} />
-                            </PieChart>
-                          </ResponsiveContainer>
-                        </div>
-                      )}
-                      {analysis.type === 'text' && (
-                        <div className="space-y-2">
-                          <div className="text-sm text-muted-foreground">
-                            총 {analysis.totalAnswers}개 응답 (최대 10개 표시)
-                          </div>
-                          <div className="space-y-2 max-h-60 overflow-y-auto">
-                            {analysis.answers?.map((answer, idx) => (
-                              <div key={idx} className="p-2 bg-muted rounded text-sm">
-                                {answer.answer_text}
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            </TabsContent>
-
-            {/* 개별 과목-강사 탭들 */}
-            {courseSessions.map((session) => {
-              const sessionAnalysis = getSubjectAnalysis(session.id);
-              const sessionSubjectQuestions = sessionAnalysis.subjectQuestions || [];
-              const sessionInstructorQuestions = sessionAnalysis.instructorQuestions || [];
-              const sessionOperationQuestions = sessionAnalysis.operationQuestions || [];
-              
-              return (
-                <TabsContent key={session.id} value={session.id} className="space-y-6">
-                  {/* 과목-강사 정보 헤더 */}
-                  <Card>
-                    <CardHeader>
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <CardTitle className="text-xl">{session.session_name}</CardTitle>
-                          <div className="text-sm text-muted-foreground mt-1">
-                            강사: {session.instructor_name}
-                            {session.instructor_email && (
-                              <span className="ml-2">({session.instructor_email})</span>
-                            )}
-                          </div>
-                        </div>
-                        <Badge variant={session.status === 'completed' ? 'default' : 'secondary'}>
-                          {session.status === 'completed' ? '완료' : session.status}
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                  </Card>
-
-                  {/* 과목별 통계 요약 */}
-                  <div className="grid gap-6 md:grid-cols-3">
-                    <Card>
-                      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-sm font-medium">과목 만족도</CardTitle>
-                        <Star className="h-4 w-4 text-muted-foreground" />
-                      </CardHeader>
-                      <CardContent>
-                        <div className="text-2xl font-bold">
-                          {sessionAnalysis.calculateCategoryAverage(sessionSubjectQuestions)}/10
-                        </div>
-                        <Progress value={parseFloat(sessionAnalysis.calculateCategoryAverage(sessionSubjectQuestions)) * 10} className="mt-2" />
-                      </CardContent>
-                    </Card>
-                    <Card>
-                      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-sm font-medium">강사 만족도</CardTitle>
-                        <TrendingUp className="h-4 w-4 text-muted-foreground" />
-                      </CardHeader>
-                      <CardContent>
-                        <div className="text-2xl font-bold">
-                          {sessionAnalysis.calculateCategoryAverage(sessionInstructorQuestions)}/10
-                        </div>
-                        <Progress value={parseFloat(sessionAnalysis.calculateCategoryAverage(sessionInstructorQuestions)) * 10} className="mt-2" />
-                      </CardContent>
-                    </Card>
-                    <Card>
-                      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-sm font-medium">응답 수</CardTitle>
-                        <Users className="h-4 w-4 text-muted-foreground" />
-                      </CardHeader>
-                      <CardContent>
-                        <div className="text-2xl font-bold">{sessionAnalysis.filteredResponses.length}</div>
-                        <div className="text-xs text-muted-foreground mt-1">총 응답</div>
-                      </CardContent>
-                    </Card>
-                  </div>
-
-                  {/* 과목별 상세 분석 */}
-                  <div className="space-y-6">
-                    {sessionAnalysis.getFilteredQuestionAnalysis([...sessionSubjectQuestions, ...sessionInstructorQuestions, ...sessionOperationQuestions]).map((analysis, index) => (
-                      <Card key={index}>
-                        <CardHeader>
-                          <CardTitle className="text-base flex items-center gap-2">
-                            {analysis.question.question_text}
-                            <Badge variant="outline" className="text-xs">
-                              {analysis.question.satisfaction_type === 'course' || analysis.question.satisfaction_type === 'subject' ? '과목' :
-                               analysis.question.satisfaction_type === 'instructor' ? '강사' :
-                               analysis.question.satisfaction_type === 'operation' ? '운영' : '기타'}
-                            </Badge>
-                          </CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                          {analysis.type === 'rating' && (
-                            <div className="space-y-4">
-                              <div className="flex items-center gap-4">
-                                <div className="text-3xl font-bold text-primary">{analysis.average}/10</div>
-                                <div className="text-sm text-muted-foreground">
-                                  총 {analysis.totalAnswers}개 응답
-                                </div>
-                              </div>
-                              <div className="w-full">
-                                <ResponsiveContainer width="100%" height={200}>
-                                  <RechartsBarChart data={analysis.chartData}>
-                                    <CartesianGrid strokeDasharray="3 3" />
-                                    <XAxis dataKey="name" />
-                                    <YAxis />
-                                    <Tooltip
-                                      formatter={(value: number | string, _name: string, props: any) => {
-                                        const percentage = props?.payload?.percentage ?? 0;
-                                        return [`${value}개 (${percentage}%)`, '응답 수'];
-                                      }}
-                                    />
-                                    <Bar dataKey="value" fill="hsl(var(--chart-1))" />
-                                  </RechartsBarChart>
-                                </ResponsiveContainer>
-                              </div>
-                            </div>
-                          )}
-                          {analysis.type === 'chart' && (
-                            <div className="w-full">
-                              <ResponsiveContainer width="100%" height={300}>
-                                <PieChart>
-                                  <Pie
-                                    data={analysis.chartData}
-                                    cx="50%"
-                                    cy="50%"
-                                    labelLine={false}
-                                    label={({ name, percentage }) => `${name} (${percentage}%)`}
-                                    outerRadius={80}
-                                    fill="hsl(var(--chart-1))"
-                                    dataKey="value"
-                                  >
-                                    {analysis.chartData.map((entry, index) => (
-                                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                                    ))}
-                                  </Pie>
-                                  <Tooltip formatter={(value, name) => [`${value}개`, name]} />
-                                </PieChart>
-                              </ResponsiveContainer>
-                            </div>
-                          )}
-                          {analysis.type === 'text' && (
-                            <div className="space-y-2">
-                              <div className="text-sm text-muted-foreground">
-                                총 {analysis.totalAnswers}개 응답 (최대 10개 표시)
-                              </div>
-                              <div className="space-y-2 max-h-60 overflow-y-auto">
-                                {analysis.answers?.map((answer, idx) => (
-                                  <div key={idx} className="p-2 bg-muted rounded text-sm">
-                                    {answer.answer_text}
-                                  </div>
-                                ))}
-                              </div>
-                            </div>
-                          )}
-                        </CardContent>
-                      </Card>
-                    ))}
-                  </div>
-                </TabsContent>
-              );
-            })}
-          </Tabs>
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={handleSendResults} size="sm" disabled={sendingResults}>
+            {sendingResults ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                전송 중...
+              </>
+            ) : (
+              <>
+                <Mail className="mr-2 h-4 w-4" /> 결과 전송
+              </>
+            )}
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleDownload} disabled={!summary}>
+            <Download className="mr-2 h-4 w-4" /> 엑셀 다운로드
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => window.print()}>
+            <Printer className="mr-2 h-4 w-4" /> 인쇄
+          </Button>
+          <Button variant="outline" size="sm" onClick={refresh} disabled={initialLoading}>
+            {initialLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> 새로고침 중
+              </>
+            ) : (
+              '새로고침'
+            )}
+          </Button>
         </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <section className="space-y-4">
+          <h2 className="text-lg font-semibold">요약 통계</h2>
+          {initialLoading && !summary ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              {renderSummaryCard('종합 만족도', formatAverage(summary?.avgOverall))}
+              {renderSummaryCard('과목 만족도', formatAverage(summary?.avgCourse))}
+              {renderSummaryCard('강사 만족도', formatAverage(summary?.avgInstructor))}
+              {renderSummaryCard('운영 만족도', formatAverage(summary?.avgOperation))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">평가형 문항 분석</h2>
+            <span className="text-sm text-muted-foreground">
+              {ratingDistributions.length} / {distributionsTotal} 문항
+            </span>
+          </div>
+          {initialLoading && ratingDistributions.length === 0 ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : ratingDistributions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">평가형 문항이 없습니다.</p>
+          ) : (
+            <div className="space-y-4">
+              {ratingDistributions.map((distribution) => (
+                <Card key={distribution.questionId}>
+                  <CardHeader>
+                    <div className="flex items-center justify-between gap-2">
+                      <CardTitle className="text-base">{distribution.questionText}</CardTitle>
+                      {distribution.satisfactionType && (
+                        <Badge variant="outline" className="text-xs uppercase">
+                          {distribution.satisfactionType}
+                        </Badge>
+                      )}
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="flex flex-wrap items-end justify-between gap-3">
+                      <div className="text-3xl font-bold text-primary">
+                        {formatAverage(distribution.average)} / 10
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        총 {distribution.totalAnswers}개 응답
+                      </div>
+                    </div>
+                    {renderRatingChart(distribution)}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+          {hasMoreDistributions && (
+            <div className="flex justify-center">
+              <Button
+                onClick={loadMoreDistributions}
+                variant="outline"
+                disabled={distributionsLoading}
+              >
+                {distributionsLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> 불러오는 중...
+                  </>
+                ) : (
+                  '더 보기'
+                )}
+              </Button>
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">선택형 문항 분포</h2>
+            <span className="text-sm text-muted-foreground">
+              {choiceDistributions.length} / {distributionsTotal} 문항
+            </span>
+          </div>
+          {initialLoading && choiceDistributions.length === 0 ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : choiceDistributions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">선택형 문항이 없습니다.</p>
+          ) : (
+            <div className="space-y-4">
+              {choiceDistributions.map((distribution) => (
+                <Card key={distribution.questionId}>
+                  <CardHeader>
+                    <div className="flex items-center justify-between gap-2">
+                      <CardTitle className="text-base">{distribution.questionText}</CardTitle>
+                      {distribution.satisfactionType && (
+                        <Badge variant="outline" className="text-xs uppercase">
+                          {distribution.satisfactionType}
+                        </Badge>
+                      )}
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="text-sm text-muted-foreground">
+                      총 {distribution.totalAnswers}개 응답
+                    </div>
+                    {renderChoiceChart(distribution)}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {otherQuestions.length > 0 && (
+          <section className="space-y-4">
+            <h2 className="text-lg font-semibold">기타 문항</h2>
+            <div className="space-y-4">
+              {otherQuestions.map((question) => (
+                <Card key={question.questionId}>
+                  <CardHeader>
+                    <CardTitle className="text-base">{question.questionText}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">
+                      해당 문항은 별도의 통계가 제공되지 않습니다. 텍스트 응답 섹션을 확인하세요.
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">텍스트 응답</h2>
+            <span className="text-sm text-muted-foreground">
+              {groupedTextAnswers.length}개의 문항 / {textAnswersTotal}개 응답
+            </span>
+          </div>
+          {initialLoading && groupedTextAnswers.length === 0 ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : groupedTextAnswers.length === 0 ? (
+            <p className="text-sm text-muted-foreground">텍스트 응답이 없습니다.</p>
+          ) : (
+            <div className="space-y-4">
+              {groupedTextAnswers.map((group) => (
+                <Card key={group.questionId}>
+                  <CardHeader>
+                    <CardTitle className="text-base">{group.questionText}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="mb-2 text-sm text-muted-foreground">
+                      총 {group.answers.length}개 응답
+                    </div>
+                    <div className="max-h-64 space-y-2 overflow-y-auto">
+                      {group.answers.map((answer) => (
+                        <div key={answer.answerId} className="rounded border bg-muted/50 p-2 text-sm">
+                          {answer.answerText}
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+          {hasMoreTextAnswers && (
+            <div className="flex justify-center">
+              <Button
+                onClick={loadMoreTextAnswers}
+                variant="outline"
+                disabled={textAnswersLoading}
+              >
+                {textAnswersLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> 불러오는 중...
+                  </>
+                ) : (
+                  '더 보기'
+                )}
+              </Button>
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">응답 목록</h2>
+            <span className="text-sm text-muted-foreground">
+              {responses.length} / {responsesTotal} 응답
+            </span>
+          </div>
+          {initialLoading && responses.length === 0 ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : responses.length === 0 ? (
+            <p className="text-sm text-muted-foreground">등록된 응답이 없습니다.</p>
+          ) : (
+            <Card>
+              <CardContent className="overflow-x-auto p-0">
+                <table className="min-w-full divide-y divide-border text-sm">
+                  <thead className="bg-muted/50">
+                    <tr>
+                      <th className="px-4 py-3 text-left font-medium">응답 ID</th>
+                      <th className="px-4 py-3 text-left font-medium">제출일</th>
+                      <th className="px-4 py-3 text-left font-medium">이메일</th>
+                      <th className="px-4 py-3 text-left font-medium">세션</th>
+                      <th className="px-4 py-3 text-left font-medium">테스트</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {responses.map((response) => (
+                      <tr key={response.id}>
+                        <td className="px-4 py-3 font-mono text-xs sm:text-sm">{response.id}</td>
+                        <td className="px-4 py-3">{formatDateTime(response.submittedAt)}</td>
+                        <td className="px-4 py-3">{response.respondentEmail ?? '-'}</td>
+                        <td className="px-4 py-3">{response.sessionId ?? '-'}</td>
+                        <td className="px-4 py-3">
+                          {response.isTest ? (
+                            <Badge variant="outline" className="text-xs text-orange-600">테스트</Badge>
+                          ) : (
+                            <span className="text-muted-foreground">실제</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          )}
+          {hasMoreResponses && (
+            <div className="flex justify-center">
+              <Button onClick={loadMoreResponses} variant="outline" disabled={responsesLoading}>
+                {responsesLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> 불러오는 중...
+                  </>
+                ) : (
+                  '더 보기'
+                )}
+              </Button>
+            </div>
+          )}
+        </section>
       </main>
     </div>
   );

--- a/src/repositories/surveyDetailRepository.ts
+++ b/src/repositories/surveyDetailRepository.ts
@@ -1,0 +1,344 @@
+import { supabase } from '@/integrations/supabase/client';
+
+type NullableNumber = number | null;
+
+export type RatingDistribution = Record<number, number>;
+
+export interface OptionCount {
+  option: string;
+  count: number;
+}
+
+export interface SurveyDetailResponse {
+  id: string;
+  submittedAt: string | null;
+  respondentEmail: string | null;
+  sessionId: string | null;
+  isTest: boolean;
+}
+
+export interface SurveyQuestionDistribution {
+  questionId: string;
+  questionText: string;
+  questionType: string;
+  satisfactionType: string | null;
+  orderIndex: number | null;
+  sessionId: string | null;
+  totalAnswers: number;
+  average: NullableNumber;
+  ratingDistribution: RatingDistribution;
+  optionCounts: OptionCount[];
+}
+
+export interface SurveyTextAnswer {
+  answerId: string;
+  questionId: string;
+  questionText: string;
+  satisfactionType: string | null;
+  orderIndex: number | null;
+  sessionId: string | null;
+  answerText: string;
+  createdAt: string | null;
+}
+
+export interface SurveyDetailSummary {
+  responseCount: number;
+  ratingResponseCount: number;
+  avgOverall: NullableNumber;
+  avgCourse: NullableNumber;
+  avgInstructor: NullableNumber;
+  avgOperation: NullableNumber;
+  questionCount: number;
+  textAnswerCount: number;
+}
+
+export interface PagedResult<T> {
+  items: T[];
+  nextCursor: number | null;
+  totalCount: number;
+}
+
+export interface SurveyDetailStatsResult {
+  summary: SurveyDetailSummary;
+  responses: PagedResult<SurveyDetailResponse>;
+  distributions: PagedResult<SurveyQuestionDistribution>;
+  textAnswers: PagedResult<SurveyTextAnswer>;
+}
+
+export interface FetchSurveyDetailParams {
+  surveyId: string;
+  includeTestData?: boolean;
+  responseCursor?: number | null;
+  responseLimit?: number;
+  distributionCursor?: number | null;
+  distributionLimit?: number;
+  textCursor?: number | null;
+  textLimit?: number;
+}
+
+const SCORE_RANGE = Array.from({ length: 10 }, (_value, index) => index + 1);
+
+export const SURVEY_DETAIL_DEFAULTS = {
+  responseLimit: 50,
+  distributionLimit: 20,
+  textLimit: 50,
+} as const;
+
+function toNumber(value: unknown): NullableNumber {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function toInteger(value: unknown): number | null {
+  const numeric = toNumber(value);
+  if (numeric === null) return null;
+  return Math.trunc(numeric);
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    const normalized = value.toLowerCase();
+    return normalized === 'true' || normalized === 't' || normalized === '1';
+  }
+  return false;
+}
+
+function parseResponses(value: unknown): SurveyDetailResponse[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const id = typeof (item as any).id === 'string' ? (item as any).id : '';
+      if (!id) return null;
+
+      return {
+        id,
+        submittedAt: typeof (item as any).submitted_at === 'string' ? (item as any).submitted_at : null,
+        respondentEmail: typeof (item as any).respondent_email === 'string' ? (item as any).respondent_email : null,
+        sessionId: typeof (item as any).session_id === 'string' ? (item as any).session_id : null,
+        isTest: toBoolean((item as any).is_test),
+      } satisfies SurveyDetailResponse;
+    })
+    .filter((item): item is SurveyDetailResponse => item !== null);
+}
+
+function parseDistribution(value: unknown): RatingDistribution {
+  const distribution: RatingDistribution = SCORE_RANGE.reduce((acc, score) => {
+    acc[score] = 0;
+    return acc;
+  }, {} as RatingDistribution);
+
+  if (!value || typeof value !== 'object') {
+    return distribution;
+  }
+
+  Object.entries(value as Record<string, unknown>).forEach(([key, raw]) => {
+    const score = Number(key);
+    if (!Number.isFinite(score) || !(score in distribution)) return;
+
+    const numeric = toNumber(raw);
+    distribution[score as keyof RatingDistribution] = numeric !== null ? numeric : 0;
+  });
+
+  return distribution;
+}
+
+function parseOptionCounts(value: unknown): OptionCount[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const optionRaw = (item as any).option;
+      const option = typeof optionRaw === 'string' ? optionRaw : optionRaw != null ? String(optionRaw) : '';
+      if (!option) return null;
+
+      const count = toInteger((item as any).count) ?? 0;
+      return { option, count } satisfies OptionCount;
+    })
+    .filter((item): item is OptionCount => item !== null)
+    .sort((a, b) => b.count - a.count || a.option.localeCompare(b.option));
+}
+
+function parseDistributions(value: unknown): SurveyQuestionDistribution[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const questionId = typeof (item as any).question_id === 'string' ? (item as any).question_id : '';
+      if (!questionId) return null;
+
+      return {
+        questionId,
+        questionText: typeof (item as any).question_text === 'string' ? (item as any).question_text : '',
+        questionType: typeof (item as any).question_type === 'string' ? (item as any).question_type : '',
+        satisfactionType: typeof (item as any).satisfaction_type === 'string' ? (item as any).satisfaction_type : null,
+        orderIndex: toInteger((item as any).order_index),
+        sessionId: typeof (item as any).session_id === 'string' ? (item as any).session_id : null,
+        totalAnswers: toInteger((item as any).total_answers) ?? 0,
+        average: toNumber((item as any).average),
+        ratingDistribution: parseDistribution((item as any).rating_distribution),
+        optionCounts: parseOptionCounts((item as any).option_counts),
+      } satisfies SurveyQuestionDistribution;
+    })
+    .filter((item): item is SurveyQuestionDistribution => item !== null)
+    .sort((a, b) => {
+      if (a.orderIndex === null && b.orderIndex === null) return a.questionText.localeCompare(b.questionText);
+      if (a.orderIndex === null) return 1;
+      if (b.orderIndex === null) return -1;
+      return a.orderIndex - b.orderIndex;
+    });
+}
+
+function parseTextAnswers(value: unknown): SurveyTextAnswer[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const answerId = typeof (item as any).answer_id === 'string' ? (item as any).answer_id : '';
+      const questionId = typeof (item as any).question_id === 'string' ? (item as any).question_id : '';
+      const answerText = typeof (item as any).answer_text === 'string' ? (item as any).answer_text : '';
+
+      if (!answerId || !questionId || !answerText) return null;
+
+      return {
+        answerId,
+        questionId,
+        questionText: typeof (item as any).question_text === 'string' ? (item as any).question_text : '',
+        satisfactionType: typeof (item as any).satisfaction_type === 'string' ? (item as any).satisfaction_type : null,
+        orderIndex: toInteger((item as any).order_index),
+        sessionId: typeof (item as any).session_id === 'string' ? (item as any).session_id : null,
+        answerText,
+        createdAt: typeof (item as any).created_at === 'string' ? (item as any).created_at : null,
+      } satisfies SurveyTextAnswer;
+    })
+    .filter((item): item is SurveyTextAnswer => item !== null)
+    .sort((a, b) => {
+      if (a.orderIndex === null && b.orderIndex === null) return a.answerId.localeCompare(b.answerId);
+      if (a.orderIndex === null) return 1;
+      if (b.orderIndex === null) return -1;
+      return a.orderIndex - b.orderIndex;
+    });
+}
+
+function parseSummary(value: unknown, fallback: {
+  responseTotal: number;
+  questionTotal: number;
+  textTotal: number;
+}): SurveyDetailSummary {
+  const base: SurveyDetailSummary = {
+    responseCount: fallback.responseTotal,
+    ratingResponseCount: 0,
+    avgOverall: null,
+    avgCourse: null,
+    avgInstructor: null,
+    avgOperation: null,
+    questionCount: fallback.questionTotal,
+    textAnswerCount: fallback.textTotal,
+  };
+
+  if (!value || typeof value !== 'object') {
+    return base;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  base.responseCount = toInteger(record.responseCount) ?? fallback.responseTotal;
+  base.ratingResponseCount = toInteger(record.ratingResponseCount) ?? 0;
+  base.avgOverall = toNumber(record.avgOverall);
+  base.avgCourse = toNumber(record.avgCourse);
+  base.avgInstructor = toNumber(record.avgInstructor);
+  base.avgOperation = toNumber(record.avgOperation);
+  base.questionCount = toInteger(record.questionCount) ?? fallback.questionTotal;
+  base.textAnswerCount = toInteger(record.textAnswerCount) ?? fallback.textTotal;
+
+  return base;
+}
+
+export const SurveyDetailRepository = {
+  async fetchSurveyDetailStats(params: FetchSurveyDetailParams): Promise<SurveyDetailStatsResult> {
+    const {
+      surveyId,
+      includeTestData = false,
+      responseCursor = 0,
+      responseLimit = SURVEY_DETAIL_DEFAULTS.responseLimit,
+      distributionCursor = 0,
+      distributionLimit = SURVEY_DETAIL_DEFAULTS.distributionLimit,
+      textCursor = 0,
+      textLimit = SURVEY_DETAIL_DEFAULTS.textLimit,
+    } = params;
+
+    const { data, error } = await supabase.rpc('get_survey_detail_stats', {
+      p_survey_id: surveyId,
+      p_include_test: includeTestData,
+      p_response_cursor: responseCursor,
+      p_response_limit: responseLimit,
+      p_distribution_cursor: distributionCursor,
+      p_distribution_limit: distributionLimit,
+      p_text_cursor: textCursor,
+      p_text_limit: textLimit,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    const row = data?.[0] ?? null;
+
+    const responseTotal = toInteger(row?.response_total_count) ?? 0;
+    const distributionTotal = toInteger(row?.distribution_total_count) ?? 0;
+    const textTotal = toInteger(row?.text_total_count) ?? 0;
+
+    const responses = parseResponses((row as any)?.responses);
+    const distributions = parseDistributions((row as any)?.question_distributions);
+    const textAnswers = parseTextAnswers((row as any)?.text_answers);
+
+    const summaryRaw = (row as any)?.summary;
+    const fallbackQuestionTotal =
+      typeof summaryRaw === 'object' && summaryRaw !== null
+        ? toInteger((summaryRaw as Record<string, unknown>).questionCount) ?? distributions.length
+        : distributions.length;
+
+    const summary = parseSummary(summaryRaw, {
+      responseTotal,
+      questionTotal: fallbackQuestionTotal,
+      textTotal,
+    });
+
+    return {
+      summary,
+      responses: {
+        items: responses,
+        nextCursor: toInteger((row as any)?.response_next_cursor),
+        totalCount: responseTotal,
+      },
+      distributions: {
+        items: distributions,
+        nextCursor: toInteger((row as any)?.distribution_next_cursor),
+        totalCount: distributionTotal,
+      },
+      textAnswers: {
+        items: textAnswers,
+        nextCursor: toInteger((row as any)?.text_next_cursor),
+        totalCount: textTotal,
+      },
+    };
+  },
+};
+
+export type SurveyDetailRepositoryType = typeof SurveyDetailRepository;

--- a/supabase/migrations/20250921153000_create_get_survey_detail_stats_function.sql
+++ b/supabase/migrations/20250921153000_create_get_survey_detail_stats_function.sql
@@ -1,0 +1,337 @@
+-- Stored procedure returning paginated survey responses with aggregated question metrics
+-- so the application can progressively render detailed analysis without downloading
+-- every answer at once.
+CREATE OR REPLACE FUNCTION public.get_survey_detail_stats(
+  p_survey_id uuid,
+  p_include_test boolean DEFAULT false,
+  p_response_cursor integer DEFAULT 0,
+  p_response_limit integer DEFAULT 50,
+  p_distribution_cursor integer DEFAULT 0,
+  p_distribution_limit integer DEFAULT 20,
+  p_text_cursor integer DEFAULT 0,
+  p_text_limit integer DEFAULT 50
+)
+RETURNS TABLE (
+  responses jsonb,
+  response_next_cursor integer,
+  response_total_count bigint,
+  question_distributions jsonb,
+  distribution_next_cursor integer,
+  distribution_total_count bigint,
+  text_answers jsonb,
+  text_next_cursor integer,
+  text_total_count bigint,
+  summary jsonb
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH filtered_responses AS (
+    SELECT
+      sr.id,
+      sr.survey_id,
+      sr.session_id,
+      sr.submitted_at,
+      sr.respondent_email,
+      COALESCE(sr.is_test, false) AS is_test
+    FROM public.survey_responses sr
+    WHERE sr.survey_id = p_survey_id
+      AND (p_include_test OR COALESCE(sr.is_test, false) = false)
+  ),
+  ordered_responses AS (
+    SELECT
+      fr.*,
+      ROW_NUMBER() OVER (ORDER BY fr.submitted_at DESC, fr.id DESC) AS rn
+    FROM filtered_responses fr
+  ),
+  response_total AS (
+    SELECT COUNT(*)::bigint AS total_count
+    FROM ordered_responses
+  ),
+  response_page AS (
+    SELECT *
+    FROM ordered_responses
+    WHERE rn > COALESCE(p_response_cursor, 0)
+    ORDER BY rn
+    LIMIT GREATEST(p_response_limit, 0)
+  ),
+  response_json AS (
+    SELECT
+      COALESCE(jsonb_agg(
+        jsonb_build_object(
+          'id', rp.id,
+          'submitted_at', rp.submitted_at,
+          'respondent_email', rp.respondent_email,
+          'session_id', rp.session_id,
+          'is_test', rp.is_test
+        )
+        ORDER BY rp.rn
+      ), '[]'::jsonb) AS items,
+      MAX(rp.rn) AS last_rn
+    FROM response_page rp
+  ),
+  question_base AS (
+    SELECT
+      sq.id,
+      sq.question_text,
+      sq.question_type,
+      sq.satisfaction_type,
+      sq.order_index,
+      sq.session_id,
+      sq.options
+    FROM public.survey_questions sq
+    WHERE sq.survey_id = p_survey_id
+  ),
+  question_count AS (
+    SELECT COUNT(*)::bigint AS total FROM question_base
+  ),
+  filtered_answers AS (
+    SELECT
+      qa.id,
+      qa.question_id,
+      qa.response_id,
+      qa.answer_text,
+      qa.answer_value,
+      qa.created_at
+    FROM public.question_answers qa
+    JOIN filtered_responses fr ON fr.id = qa.response_id
+  ),
+  answer_metrics AS (
+    SELECT
+      qb.id AS question_id,
+      qb.question_text,
+      qb.question_type,
+      qb.satisfaction_type,
+      qb.order_index,
+      qb.session_id,
+      qb.options,
+      fa.id AS answer_id,
+      fa.response_id,
+      fa.created_at,
+      fa.answer_text,
+      fa.answer_value,
+      NULLIF(TRIM(BOTH '"' FROM COALESCE(fa.answer_text, fa.answer_value::text)), '') AS answer_string,
+      CASE
+        WHEN qb.question_type IN ('scale', 'rating')
+             AND COALESCE(NULLIF(fa.answer_value::text, ''), NULLIF(fa.answer_text, '')) ~ '^[0-9]+(\.[0-9]+)?$'
+        THEN CASE
+          WHEN (COALESCE(NULLIF(fa.answer_value::text, ''), fa.answer_text))::numeric <= 5
+            THEN (COALESCE(NULLIF(fa.answer_value::text, ''), fa.answer_text))::numeric * 2
+          ELSE (COALESCE(NULLIF(fa.answer_value::text, ''), fa.answer_text))::numeric
+        END
+        ELSE NULL
+      END AS converted_rating,
+      CASE
+        WHEN qb.question_type IN ('scale', 'rating')
+             AND COALESCE(NULLIF(fa.answer_value::text, ''), NULLIF(fa.answer_text, '')) ~ '^[0-9]+(\.[0-9]+)?$'
+        THEN LEAST(
+          10,
+          GREATEST(
+            1,
+            ROUND(
+              CASE
+                WHEN (COALESCE(NULLIF(fa.answer_value::text, ''), fa.answer_text))::numeric <= 5
+                  THEN (COALESCE(NULLIF(fa.answer_value::text, ''), fa.answer_text))::numeric * 2
+                ELSE (COALESCE(NULLIF(fa.answer_value::text, ''), fa.answer_text))::numeric
+              END
+            )::int
+          )
+        )
+        ELSE NULL
+      END AS rounded_rating
+    FROM question_base qb
+    LEFT JOIN filtered_answers fa ON fa.question_id = qb.id
+  ),
+  question_stats_raw AS (
+    SELECT
+      am.question_id,
+      MIN(am.question_text) AS question_text,
+      MIN(am.question_type) AS question_type,
+      MIN(am.satisfaction_type) AS satisfaction_type,
+      MIN(am.order_index) AS order_index,
+      MIN(am.session_id) AS session_id,
+      MIN(am.options) AS options,
+      COUNT(am.answer_id) FILTER (WHERE am.answer_id IS NOT NULL) AS total_answers,
+      AVG(am.converted_rating) AS average_score,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 1 THEN 1 ELSE 0 END), 0) AS rating_count_1,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 2 THEN 1 ELSE 0 END), 0) AS rating_count_2,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 3 THEN 1 ELSE 0 END), 0) AS rating_count_3,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 4 THEN 1 ELSE 0 END), 0) AS rating_count_4,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 5 THEN 1 ELSE 0 END), 0) AS rating_count_5,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 6 THEN 1 ELSE 0 END), 0) AS rating_count_6,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 7 THEN 1 ELSE 0 END), 0) AS rating_count_7,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 8 THEN 1 ELSE 0 END), 0) AS rating_count_8,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 9 THEN 1 ELSE 0 END), 0) AS rating_count_9,
+      COALESCE(SUM(CASE WHEN am.rounded_rating = 10 THEN 1 ELSE 0 END), 0) AS rating_count_10
+    FROM answer_metrics am
+    GROUP BY am.question_id
+  ),
+  option_counts AS (
+    SELECT
+      question_id,
+      COALESCE(jsonb_agg(
+        jsonb_build_object(
+          'option', answer_string,
+          'count', option_count
+        )
+        ORDER BY option_count DESC, answer_string
+      ), '[]'::jsonb) AS options_json
+    FROM (
+      SELECT
+        am.question_id,
+        am.answer_string,
+        COUNT(*) AS option_count
+      FROM answer_metrics am
+      WHERE am.question_type IN ('multiple_choice', 'single_choice', 'dropdown', 'select')
+        AND am.answer_string IS NOT NULL
+      GROUP BY am.question_id, am.answer_string
+    ) AS option_source
+    GROUP BY question_id
+  ),
+  ordered_questions AS (
+    SELECT
+      qsr.*,
+      COALESCE(oc.options_json, '[]'::jsonb) AS option_counts,
+      ROW_NUMBER() OVER (ORDER BY qsr.order_index NULLS LAST, qsr.question_id) AS rn
+    FROM question_stats_raw qsr
+    LEFT JOIN option_counts oc ON oc.question_id = qsr.question_id
+  ),
+  question_total AS (
+    SELECT COUNT(*)::bigint AS total_count FROM ordered_questions
+  ),
+  question_page AS (
+    SELECT *
+    FROM ordered_questions
+    WHERE rn > COALESCE(p_distribution_cursor, 0)
+    ORDER BY rn
+    LIMIT GREATEST(p_distribution_limit, 0)
+  ),
+  question_json AS (
+    SELECT
+      COALESCE(jsonb_agg(
+        jsonb_build_object(
+          'question_id', qp.question_id,
+          'question_text', qp.question_text,
+          'question_type', qp.question_type,
+          'satisfaction_type', qp.satisfaction_type,
+          'order_index', qp.order_index,
+          'session_id', qp.session_id,
+          'total_answers', qp.total_answers,
+          'average', qp.average_score,
+          'rating_distribution', jsonb_build_object(
+            '1', qp.rating_count_1,
+            '2', qp.rating_count_2,
+            '3', qp.rating_count_3,
+            '4', qp.rating_count_4,
+            '5', qp.rating_count_5,
+            '6', qp.rating_count_6,
+            '7', qp.rating_count_7,
+            '8', qp.rating_count_8,
+            '9', qp.rating_count_9,
+            '10', qp.rating_count_10
+          ),
+          'option_counts', qp.option_counts
+        )
+        ORDER BY qp.rn
+      ), '[]'::jsonb) AS items,
+      MAX(qp.rn) AS last_rn
+    FROM question_page qp
+  ),
+  text_answers_base AS (
+    SELECT
+      am.answer_id,
+      am.question_id,
+      am.question_text,
+      am.satisfaction_type,
+      am.order_index,
+      am.session_id,
+      am.answer_text,
+      am.created_at
+    FROM answer_metrics am
+    WHERE am.question_type IN ('text', 'long_text', 'textarea', 'paragraph')
+      AND am.answer_text IS NOT NULL
+  ),
+  ordered_text_answers AS (
+    SELECT
+      tab.*,
+      ROW_NUMBER() OVER (ORDER BY tab.created_at DESC, tab.answer_id) AS rn
+    FROM text_answers_base tab
+  ),
+  text_total AS (
+    SELECT COUNT(*)::bigint AS total_count FROM ordered_text_answers
+  ),
+  text_page AS (
+    SELECT *
+    FROM ordered_text_answers
+    WHERE rn > COALESCE(p_text_cursor, 0)
+    ORDER BY rn
+    LIMIT GREATEST(p_text_limit, 0)
+  ),
+  text_json AS (
+    SELECT
+      COALESCE(jsonb_agg(
+        jsonb_build_object(
+          'answer_id', tp.answer_id,
+          'question_id', tp.question_id,
+          'question_text', tp.question_text,
+          'satisfaction_type', tp.satisfaction_type,
+          'order_index', tp.order_index,
+          'session_id', tp.session_id,
+          'answer_text', tp.answer_text,
+          'created_at', tp.created_at
+        )
+        ORDER BY tp.rn
+      ), '[]'::jsonb) AS items,
+      MAX(tp.rn) AS last_rn
+    FROM text_page tp
+  ),
+  summary_stats AS (
+    SELECT
+      AVG(am.converted_rating) AS avg_overall,
+      AVG(am.converted_rating) FILTER (WHERE am.satisfaction_type = 'course') AS avg_course,
+      AVG(am.converted_rating) FILTER (WHERE am.satisfaction_type = 'instructor') AS avg_instructor,
+      AVG(am.converted_rating) FILTER (WHERE am.satisfaction_type = 'operation') AS avg_operation,
+      COUNT(DISTINCT am.response_id) FILTER (WHERE am.converted_rating IS NOT NULL) AS rating_response_count
+    FROM answer_metrics am
+  )
+  SELECT
+    rj.items AS responses,
+    CASE
+      WHEN rj.last_rn IS NOT NULL AND rj.last_rn < rt.total_count THEN rj.last_rn
+      ELSE NULL
+    END AS response_next_cursor,
+    rt.total_count AS response_total_count,
+    qj.items AS question_distributions,
+    CASE
+      WHEN qj.last_rn IS NOT NULL AND qj.last_rn < qt.total_count THEN qj.last_rn
+      ELSE NULL
+    END AS distribution_next_cursor,
+    qt.total_count AS distribution_total_count,
+    tj.items AS text_answers,
+    CASE
+      WHEN tj.last_rn IS NOT NULL AND tj.last_rn < tt.total_count THEN tj.last_rn
+      ELSE NULL
+    END AS text_next_cursor,
+    tt.total_count AS text_total_count,
+    jsonb_build_object(
+      'responseCount', rt.total_count,
+      'ratingResponseCount', COALESCE(ss.rating_response_count, 0),
+      'avgOverall', ss.avg_overall,
+      'avgCourse', ss.avg_course,
+      'avgInstructor', ss.avg_instructor,
+      'avgOperation', ss.avg_operation,
+      'questionCount', qc.total,
+      'textAnswerCount', tt.total_count
+    ) AS summary
+  FROM response_json rj
+  CROSS JOIN response_total rt
+  CROSS JOIN question_json qj
+  CROSS JOIN question_total qt
+  CROSS JOIN text_json tj
+  CROSS JOIN text_total tt
+  CROSS JOIN question_count qc
+  CROSS JOIN summary_stats ss;
+$$;
+
+COMMENT ON FUNCTION public.get_survey_detail_stats(uuid, boolean, integer, integer, integer, integer, integer, integer)
+IS 'Returns paginated survey responses with aggregated question statistics for detailed analysis dashboards.';


### PR DESCRIPTION
## Summary
- add `get_survey_detail_stats` RPC to aggregate survey results with cursor-based paging
- create repository and hook to consume the RPC and expose lazy loading helpers for responses and answers
- refactor survey detail analysis page to use the new hook, add test-data toggle, and show loading progress while fetching data

## Testing
- `npm run lint` *(fails: registry returned 403 for tailwindcss, dependencies unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ce05de13608324baf1cbd9ecbc5a65