### PR TITLE
Use Supabase RPC for course report statistics

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2349,6 +2349,16 @@ export type Database = {
         Args: { admin_email: string; admin_password: string }
         Returns: undefined
       }
+      course_report_statistics: {
+        Args: {
+          year: number
+          course_name?: string | null
+          round?: number | null
+          instructor_id?: string | null
+          include_test?: boolean
+        }
+        Returns: Json
+      }
       create_instructor_account: {
         Args: {
           instructor_email: string


### PR DESCRIPTION
## Summary
- call the `course_report_statistics` Supabase RPC from the course reports repository instead of returning mock data
- parse and coerce the RPC payload so summaries, trends, instructors, and options satisfy the repository contracts
- extend the generated Supabase types with the new RPC for proper inference

## Testing
- npm run lint *(fails: requires @eslint/js dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68ce116b389c8324b8233d7df33ecb44