### PR TITLE
Fix cumulative stats test data filter operator

### DIFF
--- a/src/repositories/cumulativeStatsRepo.ts
+++ b/src/repositories/cumulativeStatsRepo.ts
@@ -43,7 +43,7 @@ function applyFilters(
   let filtered = query;
 
   if (!includeTestData) {
-    filtered = filtered.or('is_test.is.false,is_test.is.null');
+    filtered = filtered.or('is_test.eq.false,is_test.is.null');
   }
 
   if (educationYear !== null && educationYear !== undefined) {
@@ -140,7 +140,7 @@ export async function fetchCumulativeFilters(includeTestData: boolean): Promise<
       .order('course_name', { ascending: true });
 
     if (!includeTestData) {
-      query = query.or('is_test.is.false,is_test.is.null');
+      query = query.or('is_test.eq.false,is_test.is.null');
     }
 
     const { data, error } = await query;


### PR DESCRIPTION
## Summary
- replace the `is_test` filter `.or` clause in cumulative stats queries to use the PostgREST-compatible `eq` operator

## Testing
- not run (UI toggle verification requires application runtime)


------
https://chatgpt.com/codex/tasks/task_b_68ce1d70d4788324ad3613b3bb7c1e00