### PR TITLE
Fix survey analysis and course report RPC usage

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2317,14 +2317,7 @@ export type Database = {
           p_round?: number
           p_year: number
         }
-        Returns: {
-          available_courses: Json
-          available_instructors: Json
-          instructor_stats: Json
-          summary: Json
-          textual_responses: Json
-          trend: Json
-        }[]
+        Returns: Json
       }
       create_admin_user: {
         Args: { admin_email: string; admin_password: string }
@@ -2366,14 +2359,7 @@ export type Database = {
           p_round?: number
           p_year: number
         }
-        Returns: {
-          available_courses: Json
-          available_instructors: Json
-          instructor_stats: Json
-          summary: Json
-          textual_responses: Json
-          trend: Json
-        }[]
+        Returns: Json
       }
       get_current_user_role: {
         Args: Record<PropertyKey, never>
@@ -2430,12 +2416,33 @@ export type Database = {
         }[]
       }
       get_survey_analysis: {
-        Args: { survey_id_param: string }
+        Args: {
+          p_course_name?: string | null
+          p_include_test?: boolean | null
+          p_instructor_id?: string | null
+          p_round?: number | null
+          p_year?: number | null
+        }
         Returns: {
-          feedback_text: Json
-          response_count: number
-          satisfaction_scores: Json
-          survey_info: Json
+          avg_course_satisfaction: number | null
+          avg_instructor_satisfaction: number | null
+          avg_operation_satisfaction: number | null
+          avg_overall_satisfaction: number | null
+          course_name: string | null
+          description: string | null
+          education_round: number | null
+          education_year: number | null
+          expected_participants: number | null
+          instructor_id: string | null
+          instructor_name: string | null
+          is_test: boolean | null
+          last_response_at: string | null
+          question_count: number | null
+          question_type_distribution: Json | null
+          response_count: number | null
+          status: string | null
+          survey_id: string | null
+          title: string | null
         }[]
       }
       get_survey_cumulative_summary: {


### PR DESCRIPTION
## Summary
- update the Supabase type definition for `get_survey_analysis` to the new filterable signature and fields
- normalize aggregate and analysis mapping code to work with the RPC’s flat payload instead of legacy `survey_info`
- call the RPC with the proper filter arguments so the survey results and analysis views honor instructor, course, round, year, and test-data filters
- align the course report statistics RPC typing and parsing with its JSON payload so course report widgets load correctly

## Testing
- npm install *(fails: npm error 403 Forbidden when downloading tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_68ce1b0815948324ab8c2b137fde27f4