### PR TITLE
Harden survey aggregates against legacy RPC payloads

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2317,14 +2317,7 @@ export type Database = {
           p_round?: number
           p_year: number
         }
-        Returns: {
-          available_courses: Json
-          available_instructors: Json
-          instructor_stats: Json
-          summary: Json
-          textual_responses: Json
-          trend: Json
-        }[]
+        Returns: Json
       }
       create_admin_user: {
         Args: { admin_email: string; admin_password: string }
@@ -2366,14 +2359,7 @@ export type Database = {
           p_round?: number
           p_year: number
         }
-        Returns: {
-          available_courses: Json
-          available_instructors: Json
-          instructor_stats: Json
-          summary: Json
-          textual_responses: Json
-          trend: Json
-        }[]
+        Returns: Json
       }
       get_current_user_role: {
         Args: Record<PropertyKey, never>
@@ -2430,12 +2416,33 @@ export type Database = {
         }[]
       }
       get_survey_analysis: {
-        Args: { survey_id_param: string }
+        Args: {
+          p_course_name?: string | null
+          p_include_test?: boolean | null
+          p_instructor_id?: string | null
+          p_round?: number | null
+          p_year?: number | null
+        }
         Returns: {
-          feedback_text: Json
-          response_count: number
-          satisfaction_scores: Json
-          survey_info: Json
+          avg_course_satisfaction: number | null
+          avg_instructor_satisfaction: number | null
+          avg_operation_satisfaction: number | null
+          avg_overall_satisfaction: number | null
+          course_name: string | null
+          description: string | null
+          education_round: number | null
+          education_year: number | null
+          expected_participants: number | null
+          instructor_id: string | null
+          instructor_name: string | null
+          is_test: boolean | null
+          last_response_at: string | null
+          question_count: number | null
+          question_type_distribution: Json | null
+          response_count: number | null
+          status: string | null
+          survey_id: string | null
+          title: string | null
         }[]
       }
       get_survey_cumulative_summary: {

--- a/src/repositories/courseReportsRepository.ts
+++ b/src/repositories/courseReportsRepository.ts
@@ -59,13 +59,28 @@ export const CourseReportsRepository = {
   async fetchStatistics(filters: CourseReportFilters): Promise<CourseReportStatisticsResponse | null> {
     const normalizedCourseName = normalizeCourseName(filters.courseName ?? null);
 
-    const { data, error } = await supabase.rpc('course_report_statistics', {
-      p_year: filters.year,
-      p_course_name: normalizedCourseName,
-      p_round: filters.round ?? null,
-      p_instructor_id: filters.instructorId ?? null,
-      p_include_test: filters.includeTestData ?? false,
-    });
+    const payload: Record<string, unknown> = { p_year: filters.year };
+
+    if (normalizedCourseName) {
+      payload.p_course_name = normalizedCourseName;
+    }
+
+    if (filters.round !== null && filters.round !== undefined) {
+      payload.p_round = filters.round;
+    }
+
+    const trimmedInstructorId = typeof filters.instructorId === 'string'
+      ? filters.instructorId.trim()
+      : null;
+    if (trimmedInstructorId) {
+      payload.p_instructor_id = trimmedInstructorId;
+    }
+
+    if (filters.includeTestData) {
+      payload.p_include_test = true;
+    }
+
+    const { data, error } = await supabase.rpc('course_report_statistics', payload);
 
     if (error) {
       console.error('Failed to execute course_report_statistics RPC', error);
@@ -114,8 +129,46 @@ export const CourseReportsRepository = {
       return String(value);
     };
 
-    const rawData = (Array.isArray(data) && data.length > 0 ? data[0] : {}) as Record<string, unknown>;
-    const rawSummary = (rawData.summary as Record<string, unknown> | undefined) ?? {};
+    const ensureObject = (value: unknown): Record<string, unknown> => {
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          return {};
+        }
+        return ensureObject(value[0]);
+      }
+      if (value && typeof value === 'object') {
+        return value as Record<string, unknown>;
+      }
+      if (typeof value === 'string') {
+        try {
+          const parsed = JSON.parse(value);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+          }
+        } catch (parseError) {
+          console.warn('Failed to parse JSON object field from course report statistics', parseError, value);
+        }
+      }
+      return {};
+    };
+
+    const ensureArray = (value: unknown): unknown[] => {
+      if (Array.isArray(value)) {
+        return value;
+      }
+      if (typeof value === 'string') {
+        try {
+          const parsed = JSON.parse(value);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch (parseError) {
+          console.warn('Failed to parse JSON array field from course report statistics', parseError, value);
+        }
+      }
+      return [];
+    };
+
+    const rawData = ensureObject(data ?? {});
+    const rawSummary = ensureObject(rawData.summary);
 
     const summary: CourseReportSummary = {
       educationYear: toNumberWithDefault(rawSummary.educationYear, filters.year),
@@ -124,7 +177,7 @@ export const CourseReportsRepository = {
         toStringOrNull(rawSummary.normalizedCourseName) ?? normalizedCourseName,
       educationRound: toNumberOrNull(rawSummary.educationRound),
       instructorId: toStringOrNull(rawSummary.instructorId),
-      availableRounds: toNumberArray(rawSummary.availableRounds),
+      availableRounds: toNumberArray(ensureArray(rawSummary.availableRounds)),
       totalSurveys: toNumberWithDefault(rawSummary.totalSurveys, 0),
       totalResponses: toNumberWithDefault(rawSummary.totalResponses, 0),
       avgInstructorSatisfaction: toNumberOrNull(rawSummary.avgInstructorSatisfaction),
@@ -133,7 +186,7 @@ export const CourseReportsRepository = {
       instructorCount: toNumberWithDefault(rawSummary.instructorCount, 0),
     };
 
-    const rawTrend = Array.isArray(rawData.trend) ? rawData.trend : [];
+    const rawTrend = ensureArray(rawData.trend);
     const trend: CourseTrendPoint[] = rawTrend.map((item) => {
       const point = (item as Record<string, unknown>) ?? {};
       return {
@@ -145,9 +198,7 @@ export const CourseReportsRepository = {
       };
     });
 
-    const rawInstructorStats = Array.isArray(rawData.instructorStats)
-      ? rawData.instructorStats
-      : [];
+    const rawInstructorStats = ensureArray(rawData.instructorStats);
     const instructorStats: CourseInstructorStat[] = rawInstructorStats.map((item) => {
       const stat = (item as Record<string, unknown>) ?? {};
       return {
@@ -159,16 +210,12 @@ export const CourseReportsRepository = {
       };
     });
 
-    const rawTextualResponses = Array.isArray(rawData.textualResponses)
-      ? rawData.textualResponses
-      : [];
+    const rawTextualResponses = ensureArray(rawData.textualResponses);
     const textualResponses: string[] = rawTextualResponses
       .map((item) => toStringOrNull(item))
       .filter((item): item is string => item !== null);
 
-    const rawAvailableCourses = Array.isArray(rawData.availableCourses)
-      ? rawData.availableCourses
-      : [];
+    const rawAvailableCourses = ensureArray(rawData.availableCourses);
     const availableCourses: CourseOption[] = rawAvailableCourses
       .map((item) => {
         const course = (item as Record<string, unknown>) ?? {};
@@ -176,14 +223,12 @@ export const CourseReportsRepository = {
         return {
           normalizedName,
           displayName: toStringOrNull(course.displayName) ?? normalizedName,
-          rounds: toNumberArray(course.rounds),
+          rounds: toNumberArray(ensureArray(course.rounds)),
         };
       })
       .filter((course) => course.normalizedName.length > 0 || course.displayName.length > 0);
 
-    const rawAvailableInstructors = Array.isArray(rawData.availableInstructors)
-      ? rawData.availableInstructors
-      : [];
+    const rawAvailableInstructors = ensureArray(rawData.availableInstructors);
     const availableInstructors = rawAvailableInstructors
       .map((item) => {
         const instructor = (item as Record<string, unknown>) ?? {};


### PR DESCRIPTION
## Summary
- build the course report RPC payload without null parameters and trim instructor filters to avoid invalid Supabase arguments
- normalize survey analysis rows against both modern flat records and legacy survey_info JSON while tolerating bigint counters
- trim course and instructor filters before invoking get_survey_analysis so downstream filtering matches the Supabase query

## Testing
- npm run build *(fails: vite not found because dependencies could not be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68ce1b0815948324ab8c2b137fde27f4