### PR TITLE
Limit course statistics year dropdown to last decade

### DIFF
--- a/src/components/CourseStatisticsManagement.tsx
+++ b/src/components/CourseStatisticsManagement.tsx
@@ -44,7 +44,7 @@ const CourseStatisticsManagement = () => {
   const [uploadStatus, setUploadStatus] = useState<{ type: 'success' | 'error' | null; message: string }>({ type: null, message: '' });
   const { toast } = useToast();
 
-  const years = Array.from({ length: 10 }, (_, i) => new Date().getFullYear() - i + 1);
+  const years = Array.from({ length: 10 }, (_, i) => new Date().getFullYear() - i);
   const statusOptions = ['완료', '진행 중', '진행 예정', '취소'];
   const statusSet = new Set(statusOptions);
 


### PR DESCRIPTION
## Summary
- limit the course statistics year dropdown to the current year through the prior nine years so the default stays aligned with the current year

## Testing
- npm run lint *(fails: npm cannot download tailwindcss due to 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68ceb2bb5efc8324bcbbf950b341b2ea