### PR TITLE
Propagate filters to cumulative summary query

### DIFF
--- a/src/hooks/useCumulativeSurveyStats.ts
+++ b/src/hooks/useCumulativeSurveyStats.ts
@@ -132,13 +132,18 @@ export function useCumulativeSurveyStats({
 
   const loadSummary = useCallback(async () => {
     try {
-      const result = await fetchCumulativeSummary();
+      const result = await fetchCumulativeSummary({
+        searchTerm: appliedFilters.searchTerm,
+        educationYear: appliedFilters.educationYear,
+        courseName: appliedFilters.courseName,
+        includeTestData,
+      });
       setSummary(result || DEFAULT_SUMMARY);
     } catch (err) {
       console.error('Failed to fetch cumulative summary', err);
       setSummary(DEFAULT_SUMMARY);
     }
-  }, []);
+  }, [appliedFilters, includeTestData]);
 
     const loadPage = useCallback(
       async (pageNumber: number, append = false) => {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2446,7 +2446,12 @@ export type Database = {
         }[]
       }
       get_survey_cumulative_summary: {
-        Args: Record<PropertyKey, never>
+        Args: {
+          search_term?: string | null
+          education_year?: number | null
+          course_name?: string | null
+          include_test_data?: boolean | null
+        }
         Returns: {
           average_satisfaction: number
           courses_in_progress: number

--- a/src/repositories/cumulativeStatsRepo.ts
+++ b/src/repositories/cumulativeStatsRepo.ts
@@ -98,9 +98,19 @@ export async function fetchCumulativeStats({
   };
 }
 
-export async function fetchCumulativeSummary(): Promise<CumulativeSummary | null> {
+export async function fetchCumulativeSummary({
+  searchTerm,
+  educationYear,
+  courseName,
+  includeTestData,
+}: Pick<CumulativeStatsQuery, 'searchTerm' | 'educationYear' | 'courseName' | 'includeTestData'>): Promise<CumulativeSummary | null> {
   try {
-    const { data, error } = await supabase.rpc('get_survey_cumulative_summary');
+    const { data, error } = await supabase.rpc('get_survey_cumulative_summary', {
+      search_term: searchTerm ?? null,
+      education_year: educationYear ?? null,
+      course_name: courseName ?? null,
+      include_test_data: includeTestData,
+    });
 
     if (error) {
       console.error('Error fetching cumulative summary:', error);


### PR DESCRIPTION
## Summary
- propagate search, year, course, and test data filters to the `get_survey_cumulative_summary` RPC so cumulative summaries respect active filters
- update the cumulative survey stats hook to request summaries with current filters and refresh when filters or the test data toggle changes
- extend the Supabase generated types to reflect the new RPC parameters

## Testing
- npm run lint *(fails: missing @eslint/js package in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ceb2c0450483248c4683d39f24621e