### PR TITLE
Fix survey analysis RPC permissions

### DIFF
--- a/supabase/migrations/20250921083000_create_get_survey_analysis_function.sql
+++ b/supabase/migrations/20250921083000_create_get_survey_analysis_function.sql
@@ -29,6 +29,8 @@ RETURNS TABLE (
 )
 LANGUAGE sql
 STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
 AS $$
   WITH filtered AS (
     SELECT sa.*, s.description


### PR DESCRIPTION
## Summary
- run the `get_survey_analysis` RPC as a security definer with the public search path so the client can read aggregate data without RLS errors

## Testing
- npm install *(fails: registry access returned HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ced6c0292c832485049da16f874cd5