### PR TITLE
Fix survey analysis RPC permissions

### DIFF
--- a/supabase/migrations/20250921083000_create_get_survey_analysis_function.sql
+++ b/supabase/migrations/20250921083000_create_get_survey_analysis_function.sql
@@ -29,6 +29,8 @@ RETURNS TABLE (
 )
 LANGUAGE sql
 STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
 AS $$
   WITH filtered AS (
     SELECT sa.*, s.description
@@ -87,6 +89,14 @@ AS $$
   LEFT JOIN distributions d ON d.survey_id = f.survey_id
   ORDER BY f.education_year DESC, f.education_round DESC, f.course_name NULLS LAST, f.title;
 $$;
+
+GRANT EXECUTE ON FUNCTION public.get_survey_analysis(
+  integer,
+  integer,
+  text,
+  uuid,
+  boolean
+) TO authenticated, anon;
 
 COMMENT ON FUNCTION public.get_survey_analysis(integer, integer, text, uuid, boolean)
 IS 'Returns aggregated survey metrics with question type distributions filtered by year, round, course, instructor, and optional test data inclusion.';


### PR DESCRIPTION
## Summary
- run the `get_survey_analysis` RPC as a security definer with the public search path so the client can read aggregate data without RLS errors
- grant execute privileges on `get_survey_analysis` to the `anon` and `authenticated` roles so clients can call it

## Testing
- npm install *(fails: registry access returned HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ced6c0292c832485049da16f874cd5