### PR TITLE
Use survey aggregates view

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2224,6 +2224,27 @@ export type Database = {
           },
         ]
       }
+      survey_aggregates: {
+        Row: {
+          avg_course_satisfaction: number | null
+          avg_instructor_satisfaction: number | null
+          avg_operation_satisfaction: number | null
+          avg_overall_satisfaction: number | null
+          course_name: string | null
+          education_round: number | null
+          education_year: number | null
+          expected_participants: number | null
+          instructor_id: string | null
+          instructor_name: string | null
+          is_test: boolean | null
+          last_response_at: string | null
+          response_count: number | null
+          status: string | null
+          survey_id: string | null
+          title: string | null
+        }
+        Relationships: []
+      }
       survey_available_years_v1: {
         Row: {
           education_year: number | null

--- a/src/repositories/surveyAggregatesRepository.ts
+++ b/src/repositories/surveyAggregatesRepository.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
 
 // Survey Analysis Row represents the raw response from get_survey_analysis RPC
 interface SurveyAnalysisRow {
@@ -57,6 +58,9 @@ interface SurveyAggregateResult {
   aggregates: SurveyAggregate[];
   summary: SurveyAggregateSummary;
 }
+
+type SurveyAggregatesViewRow = Database['public']['Views']['survey_aggregates']['Row'];
+type SurveyDescriptionRow = Pick<Database['public']['Tables']['surveys']['Row'], 'id' | 'description'>;
 
 export type {
   SurveyAnalysisRow,
@@ -194,48 +198,97 @@ export const SurveyAggregatesRepository = {
   }: SurveyAggregateFilters): Promise<SurveyAggregateResult> {
     const instructorFilter = restrictToInstructorId ?? instructorId ?? null;
 
-    // Use surveys table directly since get_survey_analysis is for single surveys
     let query = supabase
-      .from('surveys')
+      .from('survey_aggregates')
       .select(`
-        *,
-        instructors(name)
+        survey_id,
+        title,
+        education_year,
+        education_round,
+        course_name,
+        status,
+        instructor_id,
+        instructor_name,
+        expected_participants,
+        is_test,
+        response_count,
+        last_response_at,
+        avg_overall_satisfaction,
+        avg_course_satisfaction,
+        avg_instructor_satisfaction,
+        avg_operation_satisfaction
       `);
-    
+
     if (year) query = query.eq('education_year', year);
     if (round) query = query.eq('education_round', round);
     if (courseName) query = query.eq('course_name', courseName);
     if (instructorFilter) query = query.eq('instructor_id', instructorFilter);
     if (!includeTestData) query = query.neq('is_test', true);
-    
-    const { data, error } = await query.order('created_at', { ascending: false });
+
+    const { data, error } = await query.order('last_response_at', { ascending: false });
 
     if (error) {
       console.error('Error fetching survey aggregates:', error);
       throw error;
     }
 
-    // Convert surveys to aggregate format
-    const aggregates = data?.map(survey => ({
-      survey_id: survey.id,
-      title: survey.title || '제목 없음',
-      description: survey.description,
-      education_year: survey.education_year || 0,
-      education_round: survey.education_round || 0,
-      course_name: survey.course_name,
-      status: survey.status,
-      instructor_id: survey.instructor_id,
-      instructor_name: survey.instructors?.name || null,
-      expected_participants: survey.expected_participants,
-      is_test: survey.is_test,
-      response_count: 0,
-      last_response_at: null,
-      avg_overall_satisfaction: null,
-      avg_course_satisfaction: null,
-      avg_instructor_satisfaction: null,
-      avg_operation_satisfaction: null,
-      question_count: 0,
-    })) || [];
+    const aggregatesData = (data ?? []) as SurveyAggregatesViewRow[];
+
+    const surveyIds = aggregatesData
+      .map((item) => item?.survey_id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+    const uniqueSurveyIds = Array.from(new Set(surveyIds));
+
+    const descriptionMap = new Map<string, string | null>();
+
+    if (uniqueSurveyIds.length > 0) {
+      const { data: surveyDetails, error: surveyError } = await supabase
+        .from('surveys')
+        .select('id, description')
+        .in('id', uniqueSurveyIds);
+
+      if (surveyError) {
+        console.error('Error fetching survey descriptions:', surveyError);
+      } else {
+        (surveyDetails as SurveyDescriptionRow[] | null)?.forEach((survey) => {
+          if (survey.id) {
+            descriptionMap.set(survey.id, toNullableString(survey.description));
+          }
+        });
+      }
+    }
+
+    const aggregates = aggregatesData
+      .map((survey) => {
+        const surveyId = typeof survey.survey_id === 'string' ? survey.survey_id : null;
+
+        if (!surveyId) {
+          return null;
+        }
+
+        return {
+          survey_id: surveyId,
+          title: toNullableString(survey.title) ?? '제목 없음',
+          description: descriptionMap.get(surveyId) ?? null,
+          education_year: toNumber(survey.education_year, 0),
+          education_round: toNumber(survey.education_round, 0),
+          course_name: toNullableString(survey.course_name),
+          status: toNullableString(survey.status),
+          instructor_id: toNullableString(survey.instructor_id),
+          instructor_name: toNullableString(survey.instructor_name),
+          expected_participants: toNullableNumber(survey.expected_participants),
+          is_test: toNullableBoolean(survey.is_test),
+          response_count: toNumber(survey.response_count, 0),
+          last_response_at: toNullableString(survey.last_response_at),
+          avg_overall_satisfaction: toNullableNumber(survey.avg_overall_satisfaction),
+          avg_course_satisfaction: toNullableNumber(survey.avg_course_satisfaction),
+          avg_instructor_satisfaction: toNullableNumber(survey.avg_instructor_satisfaction),
+          avg_operation_satisfaction: toNullableNumber(survey.avg_operation_satisfaction),
+          question_count: 0,
+        };
+      })
+      .filter((aggregate): aggregate is SurveyAggregate => aggregate !== null);
 
     const summary = calculateSummary(aggregates);
 


### PR DESCRIPTION
## Summary
- fetch survey aggregate metrics from the `survey_aggregates` view so response counts and satisfaction averages surface in the UI
- hydrate missing metadata (such as descriptions) via the `surveys` table and normalize the mapped values for summary calculations
- register the `survey_aggregates` view in the Supabase TypeScript definitions

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies are not installed)*
- npm install *(fails: 403 when downloading tailwindcss)*

------
https://chatgpt.com/codex/tasks/task_b_68cf632f36b483248af8818e9e76bf05