### PR TITLE
Use survey aggregates view for counts and averages

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2238,6 +2238,7 @@ export type Database = {
           instructor_name: string | null
           is_test: boolean | null
           last_response_at: string | null
+          question_count: number | null
           response_count: number | null
           status: string | null
           survey_id: string | null

--- a/src/repositories/surveyAggregatesRepository.ts
+++ b/src/repositories/surveyAggregatesRepository.ts
@@ -211,6 +211,7 @@ export const SurveyAggregatesRepository = {
         instructor_name,
         expected_participants,
         is_test,
+        question_count,
         response_count,
         last_response_at,
         avg_overall_satisfaction,
@@ -279,13 +280,13 @@ export const SurveyAggregatesRepository = {
           instructor_name: toNullableString(survey.instructor_name),
           expected_participants: toNullableNumber(survey.expected_participants),
           is_test: toNullableBoolean(survey.is_test),
+          question_count: toNumber(survey.question_count, 0),
           response_count: toNumber(survey.response_count, 0),
           last_response_at: toNullableString(survey.last_response_at),
           avg_overall_satisfaction: toNullableNumber(survey.avg_overall_satisfaction),
           avg_course_satisfaction: toNullableNumber(survey.avg_course_satisfaction),
           avg_instructor_satisfaction: toNullableNumber(survey.avg_instructor_satisfaction),
           avg_operation_satisfaction: toNullableNumber(survey.avg_operation_satisfaction),
-          question_count: 0,
         };
       })
       .filter((aggregate): aggregate is SurveyAggregate => aggregate !== null);

--- a/supabase/migrations/20250921000000_create_survey_aggregates_view.sql
+++ b/supabase/migrations/20250921000000_create_survey_aggregates_view.sql
@@ -14,6 +14,14 @@ SELECT
   i.name AS instructor_name,
   s.expected_participants,
   s.is_test,
+  COALESCE(
+    (
+      SELECT COUNT(*)
+      FROM public.survey_questions sq_all
+      WHERE sq_all.survey_id = s.id
+    ),
+    0
+  ) AS question_count,
   COUNT(DISTINCT sr.id) AS response_count,
   MAX(sr.submitted_at) AS last_response_at,
   AVG(


### PR DESCRIPTION
## Summary
- extend the survey_aggregates view to expose question counts alongside the existing response metrics
- hydrate SurveyAggregatesRepository with the question_count column so aggregates carry the precomputed total
- update Supabase types to include the new view field used by the client

## Testing
- npm run lint *(fails: missing dependency @eslint/js because npm install is blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68cf7c51ddf083248fa426170d22c6f4