### PR TITLE
Ensure get_survey_detail_stats runs as security definer

### DIFF
--- a/supabase/migrations/20250921153000_create_get_survey_detail_stats_function.sql
+++ b/supabase/migrations/20250921153000_create_get_survey_detail_stats_function.sql
@@ -25,6 +25,8 @@ RETURNS TABLE (
 )
 LANGUAGE sql
 STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
 AS $$
   WITH filtered_responses AS (
     SELECT
@@ -335,3 +337,5 @@ $$;
 
 COMMENT ON FUNCTION public.get_survey_detail_stats(uuid, boolean, integer, integer, integer, integer, integer, integer)
 IS 'Returns paginated survey responses with aggregated question statistics for detailed analysis dashboards.';
+
+GRANT EXECUTE ON FUNCTION public.get_survey_detail_stats(uuid, boolean, integer, integer, integer, integer, integer, integer) TO anon, authenticated;


### PR DESCRIPTION
## Summary
- ensure the get_survey_detail_stats function executes with elevated privileges by marking it as SECURITY DEFINER and pinning the search path to public
- grant anon and authenticated roles permission to execute the function so it is callable from client contexts

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68cf804ce1c883249cb0c13aaffe4de6