### PR TITLE
Add drop statement before get_survey_detail_stats function

### DIFF
--- a/supabase/migrations/20250921153000_create_get_survey_detail_stats_function.sql
+++ b/supabase/migrations/20250921153000_create_get_survey_detail_stats_function.sql
@@ -1,6 +1,7 @@
 -- Stored procedure returning paginated survey responses with aggregated question metrics
 -- so the application can progressively render detailed analysis without downloading
--- every answer at once.
+DROP FUNCTION IF EXISTS public.get_survey_detail_stats(uuid, boolean, integer, integer, integer, integer, integer, integer);
+
 CREATE OR REPLACE FUNCTION public.get_survey_detail_stats(
   p_survey_id uuid,
   p_include_test boolean DEFAULT false,


### PR DESCRIPTION
## Summary
- add a DROP FUNCTION statement before recreating get_survey_detail_stats so the signature updates cleanly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cfca4589388324a27dd504ef1288b8