### PR TITLE
Allow viewing completed surveys in analytics

### DIFF
--- a/supabase/migrations/20250910030229_9e203eee-416c-4bba-bc4e-4fa1e28aeb71.sql
+++ b/supabase/migrations/20250910030229_9e203eee-416c-4bba-bc4e-4fa1e28aeb71.sql
@@ -5,23 +5,25 @@
 DROP POLICY IF EXISTS "Public can view active surveys" ON public.surveys;
 DROP POLICY IF EXISTS "Public view active surveys" ON public.surveys;
 DROP POLICY IF EXISTS "View all survey statuses" ON public.surveys;
+DROP POLICY IF EXISTS "Anonymous and public can view active surveys" ON public.surveys;
 
 -- Create unified survey access policy for anonymous and public users
-CREATE POLICY "Anonymous and public can view active surveys" 
-ON public.surveys 
-FOR SELECT 
-TO anon, public 
-USING (status = ANY (ARRAY['active'::text, 'public'::text]));
+CREATE POLICY "Anonymous and public can view published surveys"
+ON public.surveys
+FOR SELECT
+TO anon, public
+USING (status = ANY (ARRAY['active'::text, 'public'::text, 'completed'::text]));
 
 -- Ensure survey_sessions are accessible to anonymous users
 DROP POLICY IF EXISTS "Public can view sessions for active surveys" ON public.survey_sessions;
-CREATE POLICY "Anonymous can view sessions for active surveys" 
-ON public.survey_sessions 
-FOR SELECT 
-TO anon, public 
+DROP POLICY IF EXISTS "Anonymous can view sessions for active surveys" ON public.survey_sessions;
+CREATE POLICY "Anonymous can view sessions for published surveys"
+ON public.survey_sessions
+FOR SELECT
+TO anon, public
 USING (survey_id IN (
-  SELECT id FROM public.surveys 
-  WHERE status = ANY (ARRAY['active'::text, 'public'::text])
+  SELECT id FROM public.surveys
+  WHERE status = ANY (ARRAY['active'::text, 'public'::text, 'completed'::text])
 ));
 
 -- Ensure anonymous access to survey responses and answers for submission
@@ -31,7 +33,7 @@ FOR INSERT
 TO anon, public 
 WITH CHECK (EXISTS (
   SELECT 1 FROM public.surveys s 
-  WHERE s.id = survey_responses.survey_id 
+  WHERE s.id = survey_responses.survey_id
   AND s.status = ANY (ARRAY['active'::text, 'public'::text])
 ));
 
@@ -42,7 +44,7 @@ TO anon, public
 WITH CHECK (EXISTS (
   SELECT 1 FROM public.survey_responses sr
   JOIN public.surveys s ON s.id = sr.survey_id
-  WHERE sr.id = question_answers.response_id 
+  WHERE sr.id = question_answers.response_id
   AND s.status = ANY (ARRAY['active'::text, 'public'::text])
 ));
 

--- a/supabase/migrations/20250921000000_create_survey_aggregates_view.sql
+++ b/supabase/migrations/20250921000000_create_survey_aggregates_view.sql
@@ -80,7 +80,7 @@ LEFT JOIN public.instructors i ON i.id = s.instructor_id
 LEFT JOIN public.survey_responses sr ON sr.survey_id = s.id
 LEFT JOIN public.question_answers qa ON qa.response_id = sr.id
 LEFT JOIN public.survey_questions sq ON sq.id = qa.question_id
-WHERE s.status IN ('completed', 'active')
+WHERE s.status IN ('completed', 'active', 'public')
 GROUP BY
   s.id,
   s.title,


### PR DESCRIPTION
## Summary
- expand the survey aggregates view to include surveys marked as `public`
- relax survey RLS so client roles can read completed surveys and related sessions for analytics queries

## Testing
- npm run lint *(fails: missing @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cfada4695083248acabea5e5df66c6