### PR TITLE
Add security context to course report statistics function

### DIFF
--- a/supabase/migrations/20250921120000_create_course_report_statistics.sql
+++ b/supabase/migrations/20250921120000_create_course_report_statistics.sql
@@ -35,6 +35,8 @@ CREATE OR REPLACE FUNCTION public.course_report_statistics(
 )
 RETURNS jsonb
 LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
 AS $$
 DECLARE
   result jsonb;
@@ -351,5 +353,7 @@ BEGIN
   ));
 END;
 $$;
+
+GRANT EXECUTE ON FUNCTION public.course_report_statistics(integer, text, integer, uuid, boolean) TO anon, authenticated;
 
 COMMENT ON FUNCTION public.course_report_statistics IS 'Returns aggregated course report metrics (responses, satisfaction scores, instructor stats, trend, text responses) for a given set of filters.';


### PR DESCRIPTION
## Summary
- run the course_report_statistics function as a security definer with the public search_path
- grant anon and authenticated roles execute access to the course_report_statistics function

## Testing
- not run (SQL migration update only)


------
https://chatgpt.com/codex/tasks/task_b_68cfea2fc92c8324919ace351cfd5a5d