### PR TITLE
Use survey analysis RPC for aggregated summaries

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2558,12 +2558,35 @@ export type Database = {
         }[]
       }
       get_survey_analysis: {
-        Args: { survey_id_param: string }
+        Args:
+          | Record<PropertyKey, never>
+          | {
+              p_course_name?: string | null
+              p_include_test?: boolean | null
+              p_instructor_id?: string | null
+              p_round?: number | null
+              p_year?: number | null
+            }
         Returns: {
-          feedback_text: Json
-          response_count: number
-          satisfaction_scores: Json
-          survey_info: Json
+          avg_course_satisfaction: number | null
+          avg_instructor_satisfaction: number | null
+          avg_operation_satisfaction: number | null
+          avg_overall_satisfaction: number | null
+          course_name: string | null
+          description: string | null
+          education_round: number | null
+          education_year: number | null
+          expected_participants: number | null
+          instructor_id: string | null
+          instructor_name: string | null
+          is_test: boolean | null
+          last_response_at: string | null
+          question_count: number | null
+          question_type_distribution: Json
+          response_count: number | null
+          status: string | null
+          survey_id: string | null
+          title: string | null
         }[]
       }
       get_survey_cumulative_summary: {


### PR DESCRIPTION
## Summary
- update Supabase `get_survey_analysis` RPC typings to reflect the new filter arguments and aggregated fields
- load survey summaries through the `get_survey_analysis` RPC in the SurveyAnalysis page and normalize the aggregated metrics & distributions

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies are not installed in the execution environment)*
- npm install *(fails: registry access to tailwindcss is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cfff4522988324b028db738015af75